### PR TITLE
Feat add descriptions

### DIFF
--- a/drivers/Perl/make-model/MANIFEST
+++ b/drivers/Perl/make-model/MANIFEST
@@ -13,6 +13,11 @@ t/005_tool.t
 t/006_delrpl.t
 t/007_model.t
 t/008_dtool.t
+t/009_table.t
 t/samples/icdc-model-props.yml
 t/samples/icdc-model.yml
 t/samples/gen3-model-overlay.yml
+t/samples/deleting-overlay.yml
+t/samples/try.yml
+META.yml
+META.json

--- a/drivers/Perl/make-model/bin/model-tool
+++ b/drivers/Perl/make-model/bin/model-tool
@@ -85,7 +85,7 @@ model-tool - Perform useful functions with MDF models
              [-T <table-out-file>] <input.yaml> [<input2.yaml> ...]
      [-d dir_to_search [-d another_dir...]]
   -g : create an SVG of model defined in input.yamls
-  -T : output a table of nodes and properties
+  -T : output a TSV table of nodes, relationships, properties
   -a : output all nodes, including unlinked nodes
   -v : verbosity (-v little ... -vvvv lots)
   -W : show all warnings ( = -vvv )

--- a/drivers/Perl/make-model/lib/Bento/MakeModel.pm
+++ b/drivers/Perl/make-model/lib/Bento/MakeModel.pm
@@ -341,7 +341,7 @@ Create an SVG file of the model using GraphViz.
 
 =item table([$filename|$filehandle])
 
-Create a flattened version of the model. Emits two (concatentated) TSV tables.
+Create a flattened version of the model. Emits three (concatentated) TSV tables.
 
 =over
 
@@ -378,6 +378,17 @@ source and destination node types.
   at_enrollment     prior_surgery    enrollment        NA        NA
   next              visit            visit             NA        NA
   of_assay          file             assay             NA        NA
+
+=item Table 3: Property Descriptions
+
+Properties may have free text descriptions in the MDF. Each property is listed
+along with this description, if available.
+
+  property                      description
+  cohort_dose                   intended or protocol dose
+  comment                       generic comment
+  concurrent_disease            Boolean indicator as to whether the patient is has any significant secondary disease condition(s)
+  concurrent_disease_type       specifics of any notable secondary disease condition(s) within the patient
 
 =back
 

--- a/drivers/Perl/make-model/lib/Bento/MakeModel.pm
+++ b/drivers/Perl/make-model/lib/Bento/MakeModel.pm
@@ -152,7 +152,9 @@ sub table {
   say $fh "";
   say $fh join("\t", qw{ property description });
   for my $p (sort {$a->name cmp $b->name } $model->props) {
-    say $fh join("\t", $p->name, $p->desc || "NA")
+    if ( $p->desc && ($p->desc !~ /\?/)) {
+      say $fh join("\t", $p->name, $p->desc);
+    }
   }
   1;
 }

--- a/drivers/Perl/make-model/lib/Bento/MakeModel.pm
+++ b/drivers/Perl/make-model/lib/Bento/MakeModel.pm
@@ -149,6 +149,11 @@ sub table {
       }
     }
   }
+  say $fh "";
+  say $fh join("\t", qw{ property description });
+  for my $p (sort {$a->name cmp $b->name } $model->props) {
+    say $fh join("\t", $p->name, $p->desc || "NA")
+  }
   1;
 }
 

--- a/drivers/Perl/make-model/lib/Bento/MakeModel/Model.pm
+++ b/drivers/Perl/make-model/lib/Bento/MakeModel/Model.pm
@@ -183,7 +183,8 @@ sub new {
     # just return whatever is there, rather than normalize to string
     $self->{_type} = $propdef->{Type} ; # && (ref $propdef->{Type} ? ref $propdef->{Type} :
     #                                            $propdef->{Type});
-    
+    $self->{_propdef}{Desc} &&
+      $self->{_propdef}{Desc} =~ s/\n/ /g;      
     unless ( $self->{_type} ) {
       WARN "Property '$name' has no Type defined";
     }

--- a/drivers/Perl/make-model/lib/Bento/MakeModel/Model.pm
+++ b/drivers/Perl/make-model/lib/Bento/MakeModel/Model.pm
@@ -192,6 +192,7 @@ sub new {
   }
   else {
     WARN "Property '$name' does not have a PropDefinitions entry";
+    $self->{_propdef} = {};
     $model->{_props}{$name} = $self;
   }
   return $self
@@ -201,6 +202,7 @@ sub tags { @{shift->{_tags}} }
 sub type { shift->{_type} }
 sub values { $_[0]->{_values} && (ref $_[0]->{_values} eq 'ARRAY' ? @{$_[0]->{_values}} : ($_[0]->{_values})) }
 sub name { shift->{_name} }
+sub desc { shift->{_propdef}{Desc} }
 sub is_required { shift->{_propdef}{Req} }
 1;
 

--- a/drivers/Perl/make-model/t/009_table.t
+++ b/drivers/Perl/make-model/t/009_table.t
@@ -23,6 +23,8 @@ my $obj = Bento::MakeModel->new(
 
 my $model = $obj->model;
 
+my $NUMDESCS = scalar grep { length $_->desc && $_->desc !~ /\?/ } $model->props;
+
 is scalar ($model->nodes), $NUMNODES, "count nodes";
 is scalar ($model->props), $NUMPROPS, "count all props";
 is scalar ($model->edge_types), $NUMETYPES, "count all edge types";
@@ -96,14 +98,12 @@ else {
   diag join("\n", $got_etypes->symmetric_difference($exp_etypes)->members);
 }
 
-if ($got_propdescs->is_equal($got_props)) {
+if ($got_propdescs->size == $NUMDESCS) {
   pass "got all prop descriptions";
 }
 else {
   fail "prop descs incorrect";
-  diag "got ".$got_propdescs->size.", expected ".$got_props->size;
-  diag "symmetric difference";
-  diag join("\n", $got_propdescs->symmetric_difference($got_props)->members);
+  diag "got ".$got_propdescs->size.", expected $NUMDESCS";
 }
 
 done_testing;


### PR DESCRIPTION
This is an update to model-tool (specifically the module called make-model/Bento/MakeModel.pm) that prints an additional table to the flat file output of `model-tool -T`: e.g.

```
  property                      description
  cohort_dose                   intended or protocol dose
  comment                       generic comment
  concurrent_disease            Boolean indicator as to whether the patient is has any significant secondary disease condition(s)
  concurrent_disease_type       specifics of any notable secondary disease condition(s) within the patient
```
Once this is merged, next steps are
* Update bento-mdf submodule in the existing model repos (icdc-model-tool, ctdc-model, bento-model)
* Push those repos to merge in the update.

At that point, Travis will use the new model-tool, and the model flatfiles will automatically update on model changes with the new feature.