### PR TITLE
Feature/#37/add comprehensive sample mdf

### DIFF
--- a/drivers/python/tests/samples/crdc_datahub_mdf.yml
+++ b/drivers/python/tests/samples/crdc_datahub_mdf.yml
@@ -1,6 +1,8 @@
 Handle: CRDC
 URI: https://datacommons.cancer.gov/
 Version: v1.0.0
+Tags:
+  Model: Sample
 Nodes:
   diagnosis:
     Props:
@@ -32,14 +34,393 @@ Nodes:
         nanoid: jordan
     nanoid: abc123
   file:
-    Props: null
-    # tags array should be valid by schema but fails validation
-    # Tags:
-    #   - deprecated
-    #   - test
+    Props:
+      - file_size
+      - list_of_strings
+      - list_of_integers
+      - list_of_numbers
+      - list_of_datetimes
+      - list_of_urls
+      - list_of_booleans
+      - list_of_TBDs
+    Term:
+      - Origin: CRDC
+        Value: file
   participant:
     Props:
       - participant_id
+      - height
+      - weight
+      - age_at_first_diagnosis
+      - race
+      - participant_bmis
     Tags:
       Template: "Yes"
-Relationships: {}
+  study:
+    Props:
+      - study_data_types
+      - experimental_strategy_and_data_subtype
+      - study_payments
+      - adult_or_childhood_study
+  sample:
+    Props:
+      - sample_weight
+      - sample_length
+      - sample_id
+      - sample_type
+      - sample_tumor_status
+      - anatomic_site
+      - collection_method
+  placeholder:
+    Props: null
+Relationships:
+  of_participant:
+    Mul: many_to_one
+    Ends:
+      - Src: diagnosis
+        Dst: participant
+      - Src: file
+        Dst: participant
+        Mul: one_to_one
+      - Src: study
+        Dst: participant
+        Mul: many_to_many
+        Tags:
+          Display: false
+    Desc: A participant can have many diagnoses.
+    Props:
+      - of_participant_id
+      - of_participant_type
+    Tags:
+      Reltag: test
+    Term:
+      - Origin: caDSR
+        Code: '2953639'
+        Value: Of participant
+        Version: '1.00'
+  of_diagnosis:
+    Mul: one_to_many
+    Ends:
+      - Src: participant
+        Dst: diagnosis
+    Props: null
+  of_file:
+    Mul: many_to_many
+    Ends:
+      - Src: participant
+        Dst: file
+    Props:
+      - of_file_id
+    nanoid: "111222"
+UniversalNodeProperties:
+  mustHave:
+    - id
+    - date
+  mayHave:
+    - transaction_id
+    - transaction_date
+UniversalRelationshipProperties:
+  mustHave:
+    - id
+  mayHave:
+    - transaction_id
+PropDefinitions:
+  id:
+    Type: string
+    Req: true
+  date:
+    Type: datetime
+    Req: Yes
+  transaction_id:
+    Type: url
+    Nul: true
+    Req: false
+  transaction_date:
+    Type: datetime
+    Key: false
+    Req: No
+  diagnosis_id:
+    Type: number
+    Desc: A unique identifier for a diagnosis.
+    Src: CRDC
+    Key: true
+    Nul: false
+  diagnosis:
+    Enum: [https:/icdo3.org/diagnosis_codes_and_terms/123]
+    Req: Preferred
+    Strict: false
+  participant_id:
+    Type: string
+  case_type:
+    Type: TBD
+  of_participant_id:
+    Type: boolean
+  of_participant_type:
+    Enum:
+      - a_participant_type
+    Deprecated: false
+  of_file_id:
+    Enum:
+      - C:/path/to/file/id.txt
+    Deprecated: true
+  height:
+    Type:
+      value_type: number
+      units:
+        - cm
+  weight:
+    Type:
+      value_type: number
+      units: [mg, kg, lbs, stone]
+      Term:
+        - Origin: CRDC
+          Code: 'weight123'
+          Value: Weight
+          Handle: weight
+  file_size:
+    Type:
+      value_type: integer
+      units:
+        - https://www.every_file_size_unit.com/bytesandstuff
+    Term:
+      - Origin: CRDC
+        Code: 'file123'
+        Value: File Size
+      - Origin: caDSR
+        Code: '11479876'
+        Value: Electronic Data File Size Integer
+        Version: '1.00'
+    Tags:
+      include_units: true
+    nanoid: nanoid
+  age_at_first_diagnosis:
+    Type:
+      value_type: integer
+      units: 
+        - years
+        - months
+        - days
+    Term:
+      - Origin: CRDC
+        Value: Age at First Diagnosis (years)
+      - Origin: caDSR
+        Value: Age at First Diagnosis in Years
+      - Origin: CCDI
+        Value: age at first diagnosis
+    Tags:
+      include_units: true
+      pref_units: days
+  race:
+    Enum:
+      - "American Indian or Alaska Native"
+      - "Asian"
+      - "Black or African American"
+      - "Hispanic or Latino"
+      - "Native Hawaiian or other Pacific Islander"
+      - "Not Allowed to Collect"
+      - "Not Reported"
+      - "Unknown"
+      - "White"
+    Strict: true
+    Term:
+      - Origin: caDSR
+        Code: '2192199'
+        Value: Race Category Text
+        Version: '1.00'
+  sample_weight:
+    Type:
+      value_type: number
+      units:
+        - pattern: ^\\d+(mg|kg|g)$
+          flavor: Perl
+        - pattern: ^\\d+(lbs|stone)$
+  sample_length:
+    Type:
+      value_type: number
+      units:
+        - path/to/sample/length/units/
+  sample_id:
+    Type:
+      pattern: ^[A-Z]{2,5}-\d{4,8}(_[A-Z\d]{2,4})?$
+      flavor: JS
+  sample_type:
+    Type:
+      https://sample_types.com/api/v1/
+  sample_tumor_status:
+    Type:
+      - Normal
+      - Peritumoral
+      - Tumor
+  anatomic_site:
+    Type:
+      - https://anatomic_sites.gov/uberon/
+  collection_method:
+    Type:
+      - path/to/collection/methods
+  list_of_strings:
+    Type:
+      value_type: list
+      item_type: string
+  list_of_integers:
+    Type:
+      value_type: list
+      item_type: integer
+  list_of_numbers:
+    Type:
+      value_type: list
+      item_type: number
+  list_of_datetimes:
+    Type:
+      value_type: list
+      item_type: datetime
+  list_of_urls:
+    Type:
+      value_type: list
+      item_type: url
+  list_of_booleans:
+    Type:
+      value_type: list
+      item_type: boolean
+  list_of_TBDs:
+    Type:
+      value_type: list
+      item_type: TBD
+  study_data_types:
+    Type:
+      value_type: list
+      item_type:
+        - Genomic
+        - Imaging
+        - Clinical
+  experimental_strategy_and_data_subtype:
+    Type:
+      value_type: list
+      item_type:
+        - http://research.activity/experimental/method/type/1
+  participant_bmis:
+    Type:
+      value_type: list
+      item_type:
+        value_type: integer
+        units: [kg, lbs, stone]
+  study_payments:
+    Type:
+      value_type: list
+      item_type:
+        value_type: number
+        units: [$, dollars, USD]
+  adult_or_childhood_study:
+    Enum:
+      - Adult
+      - Pediatric
+    Tags:
+      display_color: blue
+Terms:
+  american_indian_or_alaska_native:
+    Origin: caDSR
+    Definition: A person having origins in any of the original peoples of North and
+      South America (including Central America) and who maintains tribal affiliation
+      or community attachment. (OMB)
+    Code: '2572232'
+    Version: '1'
+    Value: 'American Indian or Alaska Native'
+    Handle: american_indian_or_alaska_native
+    Desc: A person with origins in any of the original peoples of the Americas.
+    nanoid: '125722'
+  asian:
+    Origin: caDSR
+    Definition: A person having origins in any of the original peoples of the Far
+      East, Southeast Asia, or the Indian subcontinent, including for example, Cambodia,
+      China, India, Japan, Korea, Malaysia, Pakistan, the Philippine Islands, Thailand,
+      and Vietnam. (OMB)
+    Code: '2572233'
+    Version: '1'
+    Value: Asian
+  black_or_african_american:
+    Origin: caDSR
+    Definition: A person having origins in any of the Black racial groups of Africa.
+      Terms such as \"Haitian\" or \"Negro\" can be used in addition to \"Black or
+      African American\". (OMB)
+    Code: '2572313'
+    Version: '1'
+    Value: 'Black or African American'
+  hispanic_or_latino:
+    Origin: caDSR
+    Definition: A person of Cuban, Mexican, Puerto Rican, South or Central American,
+      or other Spanish culture or origin, regardless of race. The term, \"Spanish
+      origin,\" can be used in addition to \"Hispanic or Latino.\" (OMB)
+    Code: '2581176'
+    Version: '1'
+    Value: Hispanic or Latino
+  native_hawaiian_or_other_pacific_islander:
+    Origin: caDSR
+    Definition: Denotes a person having origins in any of the original peoples of
+      Hawaii, Guam, Samoa, or other Pacific Islands. The term covers particularly
+      people who identify themselves as part-Hawaiian, Native Hawaiian, Guamanian
+      or Chamorro, Carolinian, Samoan, Chuukese (Trukese), Fijian, Kosraean, Melanesian,
+      Micronesian, Northern Mariana Islander, Palauan, Papua New Guinean, Pohnpeian,
+      Polynesian, Solomon Islander, Tahitian, Tokelauan, Tongan, Yapese, or Pacific
+      Islander, not specified.
+    Code: '2572235'
+    Version: '1'
+    Value: Native Hawaiian or Other Pacific Islander
+  not_allowed_to_collect:
+    Origin: caDSR
+    Definition: An indicator that specifies that a collection event was not permitted.
+    Code: '6662191'
+    Version: '1'
+    Value: Not Allowed To Collect
+  not_reported:
+    Origin: NCIt
+    Value: Not Reported
+  unknown:
+    Origin: caDSR
+    Definition: Not known, not observed, not recorded, or refused.
+    Code: '4266671'
+    Version: '1'
+    Value: Unknown
+    Tags:
+      display: grey_out
+  white:
+    Origin: caDSR
+    Definition: Denotes person with European, Middle Eastern, or North African ancestral
+      origin who identifies, or is identified, as White.
+    Code: '2572236'
+    Version: '1'
+    Value: White
+  normal:
+    Origin: caDSR
+    Value: Normal Tissue
+  peritumoral:
+    Origin: caDSR
+    Definition: Located in tissues surrounding a tumor.
+    Code: '4633527'
+    Version: '1'
+    Value: Peritumoral
+  tumor:
+    Origin: caDSR
+    Definition: A benign or malignant tissue growth resulting from uncontrolled cell
+      proliferation. Benign neoplastic cells resemble normal cells without exhibiting
+      significant cytologic atypia, while malignant cells exhibit overt signs such
+      as dysplastic features, atypical mitotic figures, necrosis, nuclear pleomorphism,
+      and anaplasia. Representative examples of benign neoplasms include papillomas,
+      cystadenomas, and lipomas; malignant neoplasms include carcinomas, sarcomas,
+      lymphomas, and leukemias.
+    Code: '3071117'
+    Version: '1'
+    Value: Neoplasm
+  genomic:
+    Origin: NWM
+    Value: Genomic Data
+  imaging:
+    Origin: NWM
+    Value: Imaging Data
+  clinical:
+    Origin: NWM
+    Value: Clinical Data
+  Adult:
+    Origin: MAJ
+    Value: Adult Study
+  Pediatric:
+    Origin: MAJ
+    Value: Pediatric Study

--- a/drivers/python/tests/samples/crdc_datahub_mdf.yml
+++ b/drivers/python/tests/samples/crdc_datahub_mdf.yml
@@ -93,6 +93,7 @@ Relationships:
     Props:
       - of_participant_id
       - of_participant_type
+      - of_file_id
     Tags:
       Reltag: test
     Term:
@@ -103,16 +104,9 @@ Relationships:
   of_diagnosis:
     Mul: one_to_many
     Ends:
-      - Src: participant
+      - Src: file
         Dst: diagnosis
     Props: null
-  of_file:
-    Mul: many_to_many
-    Ends:
-      - Src: participant
-        Dst: file
-    Props:
-      - of_file_id
     nanoid: "111222"
 UniversalNodeProperties:
   mustHave:

--- a/drivers/python/tests/samples/crdc_datahub_mdf.yml
+++ b/drivers/python/tests/samples/crdc_datahub_mdf.yml
@@ -1,0 +1,45 @@
+Handle: CRDC
+URI: https://datacommons.cancer.gov/
+Version: v1.0.0
+Nodes:
+  diagnosis:
+    Props:
+      - diagnosis_id
+      - diagnosis
+      - case_type
+    Desc: Properties that describe a participant's disease(s).
+    Tags:
+      Category: clinical
+      Class: primary
+      number: 1
+      cool: true
+    Term:
+      - Origin: caDSR
+        Code: "7058670"
+        Value: Diagnosis
+        Version: "1.00"
+      - Origin: UFP
+        Value: Disease or Disorder Diagnosis
+      - Origin: NBA
+        Code: "23"
+        Value: Disorder Diagnosis
+        Version: "2.00"
+        Handle: disorder_diagnosis
+        Desc: Term used by NBA to describe a diagnosis of a disorder.
+        Tags:
+          category: clinical
+        Definition: A diagnosis of a disorder.
+        nanoid: jordan
+    nanoid: abc123
+  file:
+    Props: null
+    # tags array should be valid by schema but fails validation
+    # Tags:
+    #   - deprecated
+    #   - test
+  participant:
+    Props:
+      - participant_id
+    Tags:
+      Template: "Yes"
+Relationships: {}

--- a/drivers/python/tests/samples/crdc_datahub_mdf.yml
+++ b/drivers/python/tests/samples/crdc_datahub_mdf.yml
@@ -43,6 +43,7 @@ Nodes:
       - list_of_urls
       - list_of_booleans
       - list_of_TBDs
+      - file_id
     Term:
       - Origin: CRDC
         Value: file
@@ -62,6 +63,7 @@ Nodes:
       - experimental_strategy_and_data_subtype
       - study_payments
       - adult_or_childhood_study
+      - study_id
   sample:
     Props:
       - sample_weight
@@ -151,6 +153,7 @@ PropDefinitions:
     Strict: false
   participant_id:
     Type: string
+    Key: true
   case_type:
     Type: TBD
   of_participant_id:
@@ -243,6 +246,7 @@ PropDefinitions:
     Type:
       pattern: ^[A-Z]{2,5}-\d{4,8}(_[A-Z\d]{2,4})?$
       flavor: JS
+    Key: true
   sample_type:
     Type:
       https://sample_types.com/api/v1/
@@ -315,6 +319,12 @@ PropDefinitions:
       - Pediatric
     Tags:
       display_color: blue
+  file_id:
+    Type: string
+    Key: true
+  study_id:
+    Type: string
+    Key: true
 Terms:
   american_indian_or_alaska_native:
     Origin: caDSR

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -195,18 +195,6 @@ defs:
     required:
       - value_type
       - units
-  unionType:
-    $id: "#unionType"
-    description: |
-      A unionType is an array of other types, at least one of which the
-      associated value must comply with. Analogous to the Union in Avro
-      (https://avro.apache.org/docs/current/spec.html#Unions)
-    type: array
-    items:
-      anyOf:
-        - $ref: "#/defs/simpleType"
-        - $ref: "#/defs/enumType"
-        - $ref: "#/defs/numberWithUnits"
   listType:
     $id: "#listType"
     type: object
@@ -235,16 +223,12 @@ defs:
       - item_type
   tagsSpec:
     $id: "#tagsSpec"
-    oneOf:
-        - type: array
-          items: string
-          uniqueItems: true
-        - type: object
-          additionalProperties:
-            oneOf:
-              - type: string
-              - type: number
-              - type: boolean
+    type: object
+    additionalProperties:
+      oneOf:
+        - type: string
+        - type: number
+        - type: boolean
   nodeSpec:
     $id: "#nodeSpec"
     type: object
@@ -349,7 +333,7 @@ defs:
       - Props
       - Mul
       - Ends
-  propSpec:
+  propSpec: 
     $id: "#propSpec"
     type: object
     properties:
@@ -425,15 +409,13 @@ defs:
                 $ref: "#/defs/enumType"
               -
                 $ref: "#/defs/listType"
-              -
-                $ref: "#/defs/unionType"
         -
           Enum:
             description: |
               Same as Type:[<strings>], defines an enumeration. This keyword is meant to assist
               readability. Either one of Type or Enum may be present in a property definition,
               but not both.
-            $ref: "#/defs/enumType"
+            $ref: "#/defs/enumType" 
       Tags:
         $ref: "#/defs/tagsSpec"
       Term:
@@ -504,8 +486,3 @@ defs:
     required:
       - Value
       - Origin
-      
-      
-        
-          
-      

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -114,8 +114,7 @@ defs:
   url:
     $id: "#url"
     type: string
-    pattern: |
-      ((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)
+    pattern: ((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)
   path:
     $id: "#path"
     type: string
@@ -124,8 +123,7 @@ defs:
       base url of a terminology service endpoint. The expected response from
       the server is a simple array of acceptable values as strings (possibly
       embedded somewhere in a response structure).
-    pattern: |
-      /?[A-Za-z0-9_][A-Za-z0-9._-~]*(?:/[A-Za-z0-9_][A-Za-z0-9._-~]*)*
+    pattern: /?[A-Za-z0-9_][A-Za-z0-9._-~]*(?:/[A-Za-z0-9_][A-Za-z0-9._-~]*)*
   regex:
     $id: "#regex"
     type: object
@@ -247,7 +245,6 @@ defs:
               - type: string
               - type: number
               - type: boolean
-              
   nodeSpec:
     $id: "#nodeSpec"
     type: object
@@ -290,7 +287,6 @@ defs:
         description: |
           Human-readable description of the relationship.
         type: string
-        
       Mul:
         # here, the "default" multiplicity for all Src->Dst pairs
         type: string
@@ -438,7 +434,6 @@ defs:
               readability. Either one of Type or Enum may be present in a property definition,
               but not both.
             $ref: "#/defs/enumType"
-
       Tags:
         $ref: "#/defs/tagsSpec"
       Term:


### PR DESCRIPTION
# Summary
- Add crdc_datahub_mdf.yml to test samples which contains more examples of possibilities allowed by the MDF schema
- Move regular expression patterns for url and path in mdf-schema to single lines in mdf-schema so that they validate properly
- Remove unused options (tag arrays, union type for props) from mdf-schema