### PR TITLE
Fix validation dt49

### DIFF
--- a/python/src/bento_mdf/mdf/convert.py
+++ b/python/src/bento_mdf/mdf/convert.py
@@ -196,9 +196,10 @@ def typespec_to_domain_spec(spec: str | dict | list) -> dict:
                 domain_spec["units"] = ";".join(spec["units"])
             return domain_spec
         # list type
-        if spec.get("item_type"):
+        if spec.get("item_type") or spec.get("Enum"):
             domain_spec = {"value_domain": "list"}
-            item_domain_spec = typespec_to_domain_spec(spec["item_type"])
+            list_spec = spec.get("item_type") or spec.get("Enum")
+            item_domain_spec = typespec_to_domain_spec(list_spec)
             domain_spec["item_domain"] = item_domain_spec["value_domain"]
             for key in ("units", "value_set", "url"):
                 if key not in item_domain_spec:

--- a/python/tests/samples/crdc_datahub_mdf.yml
+++ b/python/tests/samples/crdc_datahub_mdf.yml
@@ -62,6 +62,7 @@ Nodes:
   study:
     Props:
       - study_data_types
+      - study_data_types_enum
       - experimental_strategy_and_data_subtype
       - study_payments
       - adult_or_childhood_study
@@ -289,6 +290,13 @@ PropDefinitions:
     Type:
       value_type: list
       item_type:
+        - Genomic
+        - Imaging
+        - Clinical
+  study_data_types_enum:
+    Type:
+      value_type: list
+      Enum:
         - Genomic
         - Imaging
         - Clinical

--- a/python/tests/samples/list-type-test.yaml
+++ b/python/tests/samples/list-type-test.yaml
@@ -2,7 +2,7 @@ PropDefinitions:
   pt_arm_ids:
     Desc: |
       Test: A list of arm ids participated in by a patient
-    Src: Testing new schema type
+    Src: Testing schema list type
     Type:
       value_type: list
       item_type:
@@ -47,3 +47,58 @@ PropDefinitions:
         - Y
     Req: true
     Private: false
+  more_pt_arm_ids:
+    Desc: |
+      Test: A list of arm ids participated in by a patient
+    Src: Testing schema list type (alt)
+    Type:
+      value_type: list
+      Enum:
+        - A
+        - C2
+        - E
+        - L
+        - T
+        - V
+        - Z1E
+        - Z1G
+        - Z1H
+        - Z1K
+        - Z1L
+        - Z1J
+        - Z1M
+        - C1
+        - J
+        - K1
+        - K2
+        - M
+        - Z1C
+        - Z1F
+        - F
+        - G
+        - H
+        - R
+        - U
+        - S1
+        - S2
+        - X
+        - Z1A
+        - B
+        - Z1B
+        - Z1D
+        - Z1I
+        - I
+        - N
+        - P
+        - Q
+        - W
+        - Y
+    Req: true
+    Private: false
+  random_strings:
+    Desc: |
+      Test: A list of whatever strings
+    Src: Testing schema list type 
+    Type:
+      value_type: list
+      item_type: string

--- a/python/tests/samples/test-model-bad-list-type.yml
+++ b/python/tests/samples/test-model-bad-list-type.yml
@@ -1,0 +1,118 @@
+Handle: test
+Nodes:
+  case:
+    Tags:
+      this: that
+    Props:
+      - case_id
+      - patient_id
+    Term:
+      - Handle: case_term
+        Value: case
+        Origin: CTDC
+      - Value: subject
+        Origin: caDSR
+  sample:
+    Props:
+      - sample_type
+      - amount
+  file:
+    Props:
+      - md5sum
+      - file_name
+      - file_size
+  diagnosis:
+    Props:
+      - disease
+      - comorb
+Relationships:
+  of_case:
+    Mul: one_to_one
+    Ends:
+      - Src: sample
+        Dst: case
+        Mul: many_to_one
+        Props:
+          - days_to_sample
+      - Src: diagnosis
+        Dst: case
+        Term:
+          - Handle: 'of_case_dx_case_term'
+            Value: 'of_case'
+            Origin: 'Booga'
+    Term:
+      - Handle: 'of_case_term'
+        Value: 'of_case'
+        Origin: 'CTDC'
+  of_sample:
+    Mul: one_to_one
+    Ends:
+      - Src: file
+        Dst: sample
+        Mul: many_to_many
+  derived_from:
+    Tags:
+      item1: value1
+      item2: value2
+    Mul: one_to_many
+    Props:
+      - id
+    Ends:
+      - Src: file
+        Dst: file
+        Props:
+          - workflow_id
+      - Src: sample
+        Dst: sample
+PropDefinitions:
+  case_id:
+    Type:
+      pattern: "^CASE-[0-9]+$"
+    Term:
+      - Value: 'case_id'
+        Origin: 'CTDC'
+  patient_id:
+    Type: string
+  sample_type:
+    Type:
+      - normal
+      - tumor
+  comord:
+    Type:
+      value_type: list
+      items:
+        - diabetes
+        - funky cold medina
+  amount:
+    Type:
+      units:
+        - mg
+      value_type: number
+  md5sum:
+    Tags:
+      another: value3
+    Type:
+      pattern: "^[a-f0-9]{40}"
+  file_name:
+    Type: string
+  file_size:
+    Type:
+      units:
+        - Gb
+        - Mb
+      value_type: integer
+  disease:
+    Type: url
+  days_to_sample:
+    Type:
+      units:
+        - days
+      value_type: integer
+  id:
+    Type: string
+  workflow_id:
+    Type:
+      # uuid
+      pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  
+  

--- a/python/tests/samples/test-model-bad-type-value-1.yml
+++ b/python/tests/samples/test-model-bad-type-value-1.yml
@@ -1,0 +1,111 @@
+Handle: test
+Nodes:
+  case:
+    Tags:
+      this: that
+    Props:
+      - case_id
+      - patient_id
+    Term:
+      - Handle: case_term
+        Value: case
+        Origin: CTDC
+      - Value: subject
+        Origin: caDSR
+  sample:
+    Props:
+      - sample_type
+      - amount
+  file:
+    Props:
+      - md5sum
+      - file_name
+      - file_size
+  diagnosis:
+    Props:
+      - disease
+Relationships:
+  of_case:
+    Props: ~
+    Mul: one_to_one
+    Ends:
+      - Src: sample
+        Dst: case
+        Mul: many_to_one
+        Props:
+          - days_to_sample
+      - Src: diagnosis
+        Dst: case
+        Term:
+          - Handle: 'of_case_dx_case_term'
+            Value: 'of_case'
+            Origin: 'Booga'
+    Term:
+      - Handle: 'of_case_term'
+        Value: 'of_case'
+        Origin: 'CTDC'
+  of_sample:
+    Props: ~
+    Mul: one_to_one
+    Ends:
+      - Src: file
+        Dst: sample
+        Mul: many_to_many
+  derived_from:
+    Tags:
+      item1: value1
+      item2: value2
+    Mul: one_to_many
+    Props:
+      - id
+    Ends:
+      - Src: file
+        Dst: file
+        Props:
+          - workflow_id
+      - Src: sample
+        Dst: sample
+PropDefinitions:
+  case_id:
+    Type:
+      pattern: "^CASE-[0-9]+$"
+    Term:
+      - Value: 'case_id'
+        Origin: 'CTDC'
+  patient_id:
+    Type: string
+  sample_type:
+    Type: enum
+  amount:
+    Type:
+      units:
+        - mg
+      value_type: number
+  md5sum:
+    Tags:
+      another: value3
+    Type:
+      pattern: "^[a-f0-9]{40}"
+  file_name:
+    Type: string
+  file_size:
+    Type:
+      units:
+        - Gb
+        - Mb
+      value_type: integer
+  disease:
+    Type: url
+  days_to_sample:
+    Type:
+      units:
+        - days
+      value_type: integer
+  id:
+    Type: string
+  workflow_id:
+    Type:
+      # uuid
+      pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  
+  

--- a/python/tests/samples/test-model-bad-type.yml
+++ b/python/tests/samples/test-model-bad-type.yml
@@ -1,0 +1,118 @@
+Handle: test
+Nodes:
+  case:
+    Tags:
+      this: that
+    Props:
+      - case_id
+      - patient_id
+    Term:
+      - Handle: case_term
+        Value: case
+        Origin: CTDC
+      - Value: subject
+        Origin: caDSR
+  sample:
+    Props:
+      - sample_type
+      - amount
+  file:
+    Props:
+      - md5sum
+      - file_name
+      - file_size
+  diagnosis:
+    Props:
+      - disease
+      - comorb
+Relationships:
+  of_case:
+    Mul: one_to_one
+    Ends:
+      - Src: sample
+        Dst: case
+        Mul: many_to_one
+        Props:
+          - days_to_sample
+      - Src: diagnosis
+        Dst: case
+        Term:
+          - Handle: 'of_case_dx_case_term'
+            Value: 'of_case'
+            Origin: 'Booga'
+    Term:
+      - Handle: 'of_case_term'
+        Value: 'of_case'
+        Origin: 'CTDC'
+  of_sample:
+    Mul: one_to_one
+    Ends:
+      - Src: file
+        Dst: sample
+        Mul: many_to_many
+  derived_from:
+    Tags:
+      item1: value1
+      item2: value2
+    Mul: one_to_many
+    Props:
+      - id
+    Ends:
+      - Src: file
+        Dst: file
+        Props:
+          - workflow_id
+      - Src: sample
+        Dst: sample
+PropDefinitions:
+  case_id:
+    Type:
+      pattern: "^CASE-[0-9]+$"
+    Term:
+      - Value: 'case_id'
+        Origin: 'CTDC'
+  patient_id:
+    Type: string
+  sample_type:
+    Type:
+      - normal
+      - tumor
+  comord:
+    Type:
+      value_type: list
+      items:
+        - diabetes
+        - funky cold medina
+  amount:
+    Type:
+      units:
+        - mg
+      value_type: number
+  md5sum:
+    Tags:
+      another: value3
+    Type:
+      pattern: "^[a-f0-9]{40}"
+  file_name:
+    Type: string
+  file_size:
+    Type:
+      units:
+        - Gb
+        - Mb
+      value_type: integer
+  disease:
+    Type: url
+  days_to_sample:
+    Type:
+      units:
+        - days
+      value_type: integer
+  id:
+    Type: string
+  workflow_id:
+    Type:
+      # uuid
+      pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  
+  

--- a/python/tests/samples/test-model.yml
+++ b/python/tests/samples/test-model.yml
@@ -26,6 +26,7 @@ Nodes:
       - disease
 Relationships:
   of_case:
+    Props: ~
     Mul: one_to_one
     Ends:
       - Src: sample
@@ -44,6 +45,7 @@ Relationships:
         Value: 'of_case'
         Origin: 'CTDC'
   of_sample:
+    Props: ~
     Mul: one_to_one
     Ends:
       - Src: file
@@ -73,7 +75,7 @@ PropDefinitions:
   patient_id:
     Type: string
   sample_type:
-    Type:
+    Enum:
       - normal
       - tumor
   amount:

--- a/python/tests/test_001validate.py
+++ b/python/tests/test_001validate.py
@@ -36,6 +36,8 @@ test_enum_and_type_kw_files = [
     tdir / "samples" / "ctdc_model_properties_enum_and_type_kw.yaml",
 ]
 crdc_dh_file = tdir / "samples" / "crdc_datahub_mdf.yml"
+test_model_file = tdir / "samples" / "test-model.yml"
+test_model_file_bad_type_value = tdir / "samples" / "test-model-bad-type-value-1.yml"
 
 
 def test_with_all_file_args():
@@ -97,7 +99,7 @@ def test_list_type():
     assert v
     assert v.load_and_validate_schema()
     assert v.load_and_validate_yaml()
-    v.validate_instance_with_schema()
+    assert v.validate_instance_with_schema()
 
 
 def test_enum_vs_type_kw():
@@ -105,7 +107,7 @@ def test_enum_vs_type_kw():
     assert v
     assert v.load_and_validate_schema()
     assert v.load_and_validate_yaml()
-    v.validate_instance_with_schema()
+    assert v.validate_instance_with_schema()
 
 
 def test_enum_and_type_kw():
@@ -122,4 +124,23 @@ def test_validate_crdc_model():
     assert v
     assert v.load_and_validate_schema()
     assert v.load_and_validate_yaml()
-    v.validate_instance_with_schema()
+    assert v.validate_instance_with_schema()
+
+
+def test_example_model():
+    v = MDFValidator(test_latest_schema, test_model_file)
+    assert v
+    assert v.load_and_validate_schema()
+    assert v.load_and_validate_yaml()
+    assert v.validate_instance_with_schema()
+    
+
+def test_bad_type_value():
+    # test that 'Type: enum' is invalid
+    v = MDFValidator(test_latest_schema, test_model_file_bad_type_value,
+                     raise_error = True)
+    assert v
+    assert v.load_and_validate_schema()
+    assert v.load_and_validate_yaml()
+    with pytest.raises(ValidationError):
+        v.validate_instance_with_schema()

--- a/python/tests/test_001validate.py
+++ b/python/tests/test_001validate.py
@@ -38,7 +38,7 @@ test_enum_and_type_kw_files = [
 crdc_dh_file = tdir / "samples" / "crdc_datahub_mdf.yml"
 test_model_file = tdir / "samples" / "test-model.yml"
 test_model_file_bad_type_value = tdir / "samples" / "test-model-bad-type-value-1.yml"
-
+test_model_file_bad_list_type = tdir / "samples" / "test-model-bad-list-type.yml"
 
 def test_with_all_file_args():
     sch = test_schema_file.open()
@@ -138,6 +138,16 @@ def test_example_model():
 def test_bad_type_value():
     # test that 'Type: enum' is invalid
     v = MDFValidator(test_latest_schema, test_model_file_bad_type_value,
+                     raise_error = True)
+    assert v
+    assert v.load_and_validate_schema()
+    assert v.load_and_validate_yaml()
+    with pytest.raises(ValidationError):
+        v.validate_instance_with_schema()
+
+def test_bad_list_type():
+    # tests invalid list type spec
+    v = MDFValidator(test_latest_schema, test_model_file_bad_list_type,
                      raise_error = True)
     assert v
     assert v.load_and_validate_schema()

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -224,3 +224,12 @@ class TestDataHubModel:
     def test_property_is_required_default(self) -> None:
         """Test "is_required" attribute set to False when "Req" not present in MDF."""
         assert self.m.model.props[("diagnosis", "diagnosis_id")].is_required is False
+
+    def test_enum_list_type(self) -> None:
+        """Test list types expressed as (value_type, item_type) and (value_type, Enum)"""
+        sdt = self.m.model.props[('study', 'study_data_types')]
+        sdte = self.m.model.props[('study', 'study_data_types_enum')]
+        assert len(sdt.terms) == 3
+        assert len(sdte.terms) == 3
+        assert 'Genomic' in sdt.terms
+        assert 'Imaging' in sdte.terms

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -218,11 +218,19 @@ defs:
             $ref: "#/defs/enumType"
           -
             $ref: "#/defs/numberWithUnits"
+      Enum:
+        $ref: "#/defs/enumType"
       Tags:
         $ref: "#/defs/tagsSpec"
-    required:
-      - value_type
-      - item_type
+    oneOf:
+      -
+        required:
+          - value_type
+          - item_type
+      -
+        required:
+          - value_type
+          - Enum
   tagsSpec:
     $id: "#tagsSpec"
     type: object
@@ -406,9 +414,9 @@ defs:
           -
             $ref: "#/defs/url"
           -
-            $ref: "#/defs/enumType"
-          -
             $ref: "#/defs/listType"
+          -
+            $ref: "#/defs/enumType"
       Enum:
         description: |
               Same as Type:[<strings>], defines an enumeration. This keyword is meant to assist

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -157,7 +157,7 @@ defs:
       enumType (an array - could be size 1; or a reference to value
       domain api)
     items:
-      oneOf:
+      anyOf:
         -
           type:
             string
@@ -388,36 +388,33 @@ defs:
           found in the specified Enum. This is useful when the acceptable value list has not
           been solidified in initial development.
         type: boolean
-      oneOf:
-        -
-          Type:
-            description: |
+      Type:
+        description: |
               Property values can have (1) simple types (number, integer, string
               datetime, or --if necessary-- \'TBD\'; (2) a number_with_units type
               (e.g., { \"value_type\":\"integer\", \"units\":\"mm\" }); (3) a regular
               expression that a (string) value must match; (4) an enumeration
               of acceptable values, or a url or path fragment to an api that will validate against
               such a list.
-            oneOf:
-              -
-                $ref: "#/defs/simpleType"
-              -
-                $ref: "#/defs/numberWithUnits"
-              -
-                $ref: "#/defs/regex"
-              -
-                $ref: "#/defs/url"
-              -
-                $ref: "#/defs/enumType"
-              -
-                $ref: "#/defs/listType"
-        -
-          Enum:
-            description: |
+        oneOf:
+          -
+            $ref: "#/defs/simpleType"
+          -
+            $ref: "#/defs/numberWithUnits"
+          -
+            $ref: "#/defs/regex"
+          -
+            $ref: "#/defs/url"
+          -
+            $ref: "#/defs/enumType"
+          -
+            $ref: "#/defs/listType"
+      Enum:
+        description: |
               Same as Type:[<strings>], defines an enumeration. This keyword is meant to assist
               readability. Either one of Type or Enum may be present in a property definition,
               but not both.
-            $ref: "#/defs/enumType" 
+        $ref: "#/defs/enumType" 
       Tags:
         $ref: "#/defs/tagsSpec"
       Term:


### PR DESCRIPTION
1) Fixes problem in Type: validation (where 'Type: enum' was not
called invalid, although 'enum' is not in the list of
simple types) - correctly expressing alternative, mutual exclusive
properties in the schema.

2) Fixes the #/def/url matcher regexp which probably had never been
in correct JS form (required by the JSONSchema spec)

3) Fixes test (in 001) of the CRDC example MDF, which did not 'assert'
the result of validate_instance_with_schema and so was a no-op.
(once asserted, I found the issue with the URL regexp)

4) Adds test that 'Type: enum' validation is fixed