### PR TITLE
Feature/datateam 38/load separate enum yaml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,15 +1,13 @@
 [project]
 name = "bento-mdf"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python driver/validator for Bento Model Description Format"
-authors = [
-    { name="Mark A. Jensen", email = "mark.jensen@nih.gov"}
-]
+authors = [{ name = "Mark A. Jensen", email = "mark.jensen@nih.gov" }]
 requires-python = ">=3.8"
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache License"
+    "License :: OSI Approved :: Apache License",
 ]
 
 [project.urls]
@@ -18,11 +16,9 @@ classifiers = [
 
 [tool.poetry]
 name = "bento-mdf"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python driver/validator for Bento Model Description Format"
-authors = [
-    "Mark A. Jensen <mark.jensen@nih.gov>"
-]
+authors = ["Mark A. Jensen <mark.jensen@nih.gov>"]
 license = "Apache 2.0"
 readme = "README.md"
 include = ["logs/log.ini"]
@@ -49,7 +45,7 @@ jupyter = "^1.0.0"
 python-semantic-release = "^7.33.0"
 pytest-cov = "^4.0.0"
 sphinx = "5.3.0"
-myst-nb = {version = "^0.17.1", python = "^3.8"}
+myst-nb = { version = "^0.17.1", python = "^3.8" }
 sphinx-autoapi = "^2.0.1"
 sphinx-rtd-theme = "^1.1.1"
 
@@ -67,11 +63,8 @@ upload_to_release = true
 upload_to_pypi = false
 remove_dist = false
 patch_without_tag = true
-major_on_zero = false # while major version on 0.y.z, won't bump to 1.0.0
-version_source = "tag" # temp?
+major_on_zero = false                       # while major version on 0.y.z, won't bump to 1.0.0
+version_source = "tag"                      # temp?
 
 [tool.pytest.ini_options]
-filterwarnings = [
-   "ignore::UserWarning",
-   ]
-   
+filterwarnings = ["ignore::UserWarning"]

--- a/python/src/bento_mdf/mdf/__init__.py
+++ b/python/src/bento_mdf/mdf/__init__.py
@@ -1,2 +1,2 @@
 # mdf
-from .mdf import MDF
+from .mdf import MDF, convert_github_url

--- a/python/src/bento_mdf/mdf/convert.pyi
+++ b/python/src/bento_mdf/mdf/convert.pyi
@@ -1,0 +1,39 @@
+from typing import overload
+
+from bento_meta.objects import Edge, Node, Property, Tag, Term
+
+@overload
+def spec_to_entity(
+    hdl: str | None,
+    spec: dict,
+    init: dict,
+    ent_cls: type[Node],
+) -> Node: ...
+@overload
+def spec_to_entity(
+    hdl: str | None,
+    spec: dict,
+    init: dict,
+    ent_cls: type[Edge],
+) -> Edge: ...
+@overload
+def spec_to_entity(
+    hdl: str | None,
+    spec: dict,
+    init: dict,
+    ent_cls: type[Property],
+) -> Property: ...
+@overload
+def spec_to_entity(
+    hdl: str | None,
+    spec: dict,
+    init: dict,
+    ent_cls: type[Term],
+) -> Term: ...
+@overload
+def spec_to_entity(
+    hdl: str | None,
+    spec: dict,
+    init: dict,
+    ent_cls: type[Tag],
+) -> Tag: ...

--- a/python/src/bento_mdf/mdf/mdf.py
+++ b/python/src/bento_mdf/mdf/mdf.py
@@ -437,7 +437,14 @@ class MDF:
                     return {}
                 return enum_mdf.as_dict()  # type: ignore reportReturnType
         if re.match("(?:file|https?)://", enum_ref):  # looks like a url
-            pass  # TODO: load enum from url
+            vargs = []
+            self.load_yaml_vargs_from_url(vargs, enum_ref)
+            v = MDFValidator(None, *vargs)
+            enum_mdf = v.load_and_validate_yaml()
+            if not enum_mdf:
+                self.logger.error("Error loading enum from url '%s'", enum_ref)
+                return {}
+            return enum_mdf.as_dict()  # type: ignore reportReturnType
         return {}
 
     def merge_enum_reference(self, prop: Property) -> None:

--- a/python/tests/samples/test-model-sep-enum-race.yml
+++ b/python/tests/samples/test-model-sep-enum-race.yml
@@ -1,0 +1,37 @@
+PropDefinitions:
+  race:
+    - "American Indian or Alaska Native"
+    - "Asian"
+    - "Black or African American"
+    - "Hispanic or Latino"
+    - "Middle Eastern or North African"
+    - "Native Hawaiian or other Pacific Islander"
+    - "Not Allowed to Collect"
+    - "Not Reported"
+    - "Unknown"
+    - "White"
+Terms:
+  White:
+    Origin: caDSR
+    Definition: Denotes person with European, Middle Eastern, or North African ancestral
+      origin who identifies, or is identified, as White.
+    Code: '2572236'
+    Version: '1'
+    Value: White
+  Black or African American:
+    Origin: caDSR
+    Definition: A person having origins in any of the Black racial groups of Africa.
+      Terms such as \"Haitian\" or \"Negro\" can be used in addition to \"Black or
+      African American\". (OMB)
+    Code: '2572313'
+    Version: '1'
+    Value: 'Black or African American'
+  Asian:
+    Origin: caDSR
+    Definition: A person having origins in any of the original peoples of the Far
+      East, Southeast Asia, or the Indian subcontinent, including for example, Cambodia,
+      China, India, Japan, Korea, Malaysia, Pakistan, the Philippine Islands, Thailand,
+      and Vietnam. (OMB)
+    Code: '2572233'
+    Version: '1'
+    Value: Asian

--- a/python/tests/samples/test-model-sep-enum-sab.yml
+++ b/python/tests/samples/test-model-sep-enum-sab.yml
@@ -1,0 +1,26 @@
+PropDefinitions:
+  sex_at_birth:
+    - "Female"
+    - "Intersex"
+    - "Male"
+    - "Not Reported"
+    - "Unknown"
+    - "Don't Know"
+    - "Decline to answer"
+    - "None of These Describe Me"
+    - "Prefer Not to Answer"
+Terms:
+  Female:
+    Origin: caDSR
+    Definition: An individual who reports belonging to the cultural gender role distinction
+      of female.
+    Code: '2567172'
+    Version: '1'
+    Value: Female
+  Male:
+    Origin: caDSR
+    Definition: An individual who reports belonging to the cultural gender role distinction
+      of male.
+    Code: '2567171'
+    Version: '1'
+    Value: Male  

--- a/python/tests/samples/test-model-sep-enum-url.yml
+++ b/python/tests/samples/test-model-sep-enum-url.yml
@@ -1,0 +1,36 @@
+Handle: CCDI
+Version: "2.0.0_SEP_ENUM"
+Nodes:
+  participant:
+    Desc: "The participant node is comprised of properties which describe the participant attributes."
+    Props:
+      - race
+      - sex_at_birth
+Relationships: {}
+PropDefinitions:
+  race:
+    Desc: The text for reporting information about race based on the Office of Management and Budget (OMB) categories SPD 15 (spd15revision.gov).
+    Term:
+      - Origin: caDSR
+        Code: "2192199"
+        Value: Race Category Text
+        Version: "1.00"
+    Type:
+      value_type: list
+      item_type:
+        - https://github.com/CBIIT/ccdi-model/blob/CCDIDC-1353-enum_structure_updates/model-desc/enum_lists/race.yml
+    Req: true
+    Strict: false
+    Private: false
+  sex_at_birth:
+    Desc: "A textual description of a person's sex at birth."
+    Term:
+      - Origin: caDSR
+        Code: '7572817'
+        Value: Person Sex at Birth Category
+        Version: "2.0"
+    Enum:
+      - https://github.com/CBIIT/ccdi-model/blob/a0c5d0e4b460ef9209b8a8a0d2837acbf610108f/model-desc/enum_lists/sex_at_birth.yml
+    Req: true
+    Strict: false
+    Private: false

--- a/python/tests/samples/test-model-sep-enum.yml
+++ b/python/tests/samples/test-model-sep-enum.yml
@@ -1,0 +1,36 @@
+Handle: CCDI
+Version: "2.0.0_SEP_ENUM"
+Nodes:
+  participant:
+    Desc: "The participant node is comprised of properties which describe the participant attributes."
+    Props:
+      - race
+      - sex_at_birth
+Relationships: {}
+PropDefinitions:
+  race:
+    Desc: The text for reporting information about race based on the Office of Management and Budget (OMB) categories SPD 15 (spd15revision.gov).
+    Term:
+      - Origin: caDSR
+        Code: "2192199"
+        Value: Race Category Text
+        Version: "1.00"
+    Type:
+      value_type: list
+      item_type:
+        - /tests/samples/test-model-sep-enum-race.yml
+    Req: true
+    Strict: false
+    Private: false
+  sex_at_birth:
+    Desc: "A textual description of a person's sex at birth."
+    Term:
+      - Origin: caDSR
+        Code: '7572817'
+        Value: Person Sex at Birth Category
+        Version: "2.0"
+    Enum:
+      - /tests/samples/test-model-sep-enum-sab.yml
+    Req: true
+    Strict: false
+    Private: false

--- a/python/tests/samples/test_urls.py
+++ b/python/tests/samples/test_urls.py
@@ -1,0 +1,67 @@
+TEST_CONVERT_URLS = [
+    # look like (input_url, expected_output_url)
+    (
+        "https://github.com/user/repo/blob/main/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/master/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/master/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/feature-branch/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/feature-branch/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/folder1/folder2/file.txt",
+        "https://raw.githubusercontent.com/user/repo/main/folder1/folder2/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/v1.0.0/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/v1.0.0/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/abc123def456/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/abc123def456/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/feature/new-feature/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/feature/new-feature/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/version-1.0/path/to/file.txt",
+        "https://raw.githubusercontent.com/user/repo/version-1.0/path/to/file.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/path/to/file with spaces.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/file with spaces.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/path/to/file%20with%20encoded%20spaces.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/file%20with%20encoded%20spaces.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/path/to/特殊字符.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/特殊字符.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/path/to/file_with_underscores.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/file_with_underscores.txt",
+    ),
+    (
+        "https://github.com/user/repo/blob/main/path/to/file-with-dashes.txt",
+        "https://raw.githubusercontent.com/user/repo/main/path/to/file-with-dashes.txt",
+    ),
+    (
+        "https://github.company.com/user/repo/blob/main/path/to/file.txt",
+        "https://github.company.com/user/repo/blob/main/path/to/file.txt",
+    ),  # Should not transform
+    (
+        "https://github.com/user/repo",
+        "https://github.com/user/repo",
+    ),  # Should not transform
+    (
+        "https://github.com/user/repo/tree/main/folder1",
+        "https://github.com/user/repo/tree/main/folder1",
+    ),  # Should not transform
+]

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -27,7 +27,8 @@ CCDI_MODEL_URL = (
 CCDI_PROPS_URL = (
     "https://github.com/CBIIT/ccdi-model/blob/main/model-desc/ccdi-model-props.yml"
 )
-TEST_SEP_ENUM_MODEL_FILE = TDIR / "samples" / "test-model-sep-enum.yml"
+TEST_SEP_ENUM_MODEL_FILE_PATH = TDIR / "samples" / "test-model-sep-enum.yml"
+TEST_SEP_ENUM_MODEL_FILE_URL = TDIR / "samples" / "test-model-sep-enum-url.yml"
 
 
 def test_class() -> None:
@@ -261,18 +262,30 @@ def test_load_repo_url() -> None:
     assert m.model
 
 
-def test_load_separate_enums_from_file_path() -> None:
-    """Test loading model where enum list in separate file."""
-    m = MDF(TEST_SEP_ENUM_MODEL_FILE, handle="CCDI")
-    # sex_at_birth\
-    print(m.model.terms)
-    print(m.model.props[("participant", "sex_at_birth")].terms)
+def test_load_separate_enums_yaml_from_file_path() -> None:
+    """Test loading model where enum list in separate yaml file referenced by path."""
+    m = MDF(TEST_SEP_ENUM_MODEL_FILE_PATH, handle="CCDI")
+    # sex_at_birth
     assert "female" in m.model.props[("participant", "sex_at_birth")].terms
     assert ("male", "caDSR") in m.model.terms
     assert "intersex" in m.model.props[("participant", "sex_at_birth")].terms
     assert ("none_of_these_describe_me", "CCDI") in m.model.terms
     # race
-    print(m.model.props[("participant", "race")].terms)
+    assert "asian" in m.model.props[("participant", "race")].terms
+    assert ("white", "caDSR") in m.model.terms
+    assert "hispanic_or_latino" in m.model.props[("participant", "race")].terms
+    assert ("middle_eastern_or_north_african", "CCDI") in m.model.terms
+
+
+def test_load_separate_enums_yaml_from_url() -> None:
+    """Test loading model where enum list in separate yaml file referenced by url."""
+    m = MDF(TEST_SEP_ENUM_MODEL_FILE_URL, handle="CCDI")
+    # sex_at_birth
+    assert "female" in m.model.props[("participant", "sex_at_birth")].terms
+    assert ("male", "caDSR") in m.model.terms
+    assert "intersex" in m.model.props[("participant", "sex_at_birth")].terms
+    assert ("none_of_these_describe_me", "CCDI") in m.model.terms
+    # race
     assert "asian" in m.model.props[("participant", "race")].terms
     assert ("white", "caDSR") in m.model.terms
     assert "hispanic_or_latino" in m.model.props[("participant", "race")].terms

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -27,6 +27,7 @@ CCDI_MODEL_URL = (
 CCDI_PROPS_URL = (
     "https://github.com/CBIIT/ccdi-model/blob/main/model-desc/ccdi-model-props.yml"
 )
+TEST_SEP_ENUM_MODEL_FILE = TDIR / "samples" / "test-model-sep-enum.yml"
 
 
 def test_class() -> None:
@@ -185,7 +186,9 @@ def test_create_model_with_terms_section() -> None:
 class TestDataHubModel:
     """Tests for parts of the CRDC DataHub sample model."""
 
-    m = MDF(CRDC_MODEL_FILE)
+    def setup_method(self) -> None:
+        """Set up MDF for testing."""
+        self.m = MDF(CRDC_MODEL_FILE)
 
     def test_create_dh_model(self) -> None:
         """Test creating the CRDC model."""
@@ -256,3 +259,21 @@ def test_load_repo_url() -> None:
     m.load_yaml()
     m.create_model()
     assert m.model
+
+
+def test_load_separate_enums_from_file_path() -> None:
+    """Test loading model where enum list in separate file."""
+    m = MDF(TEST_SEP_ENUM_MODEL_FILE, handle="CCDI")
+    # sex_at_birth\
+    print(m.model.terms)
+    print(m.model.props[("participant", "sex_at_birth")].terms)
+    assert "female" in m.model.props[("participant", "sex_at_birth")].terms
+    assert ("male", "caDSR") in m.model.terms
+    assert "intersex" in m.model.props[("participant", "sex_at_birth")].terms
+    assert ("none_of_these_describe_me", "CCDI") in m.model.terms
+    # race
+    print(m.model.props[("participant", "race")].terms)
+    assert "asian" in m.model.props[("participant", "race")].terms
+    assert ("white", "caDSR") in m.model.terms
+    assert "hispanic_or_latino" in m.model.props[("participant", "race")].terms
+    assert ("middle_eastern_or_north_african", "CCDI") in m.model.terms

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -155,7 +155,9 @@ defs:
       array
     description: |
       enumType (an array - could be size 1; or a reference to value
-      domain api)
+      domain api). Reference to value domain could be a URL or a path
+      that points to either a list of acceptable values or part of a
+      set of MDF yaml files that define the value domain (term list and defs)
     items:
       anyOf:
         -


### PR DESCRIPTION
- add functionality to MDF class to load an enum by reference from a path to a MDF portion containing an enumerated value set for the prop and (optional) term defs for included terms
- add functionality to convert MDF file links to GitHub `blob` URLs to `raw` URLs
- add convert.pyi stub with overloads for spec_to_entity so that the return type matches the ent_cls argument type
- Bump to version 0.10.2