### PR TITLE
Modified MDFDataValidator class and added unittest

### DIFF
--- a/python/src/bento_mdf/mdf/templates/pymodel.py.jinja2
+++ b/python/src/bento_mdf/mdf/templates/pymodel.py.jinja2
@@ -9,7 +9,7 @@ from typing import Optional, Annotated, List
 from annotated_types import Predicate, Unit
 from enum import Enum
 from datetime import datetime
-from pydantic import BaseModel, Field, WithJsonSchema, AnyUrl
+from pydantic import BaseModel, Field, WithJsonSchema, AnyUrl, ConfigDict
 
 def MatchedStrType(pat : str):
     return Annotated[str,
@@ -22,34 +22,41 @@ def MatchedStrType(pat : str):
 def PathType():
     return MatchedStrType("^/.*")
 
-{% for node in model.nodes.values() %}
+{# Make node class strict to noted fields/properties #}
+class MDFBaseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
+{% for node in model.nodes.values() %}
 {% for pr in node.props.values() %}
 {% if pr.value_domain == 'value_set' or pr.item_domain == 'value_set' %}
-{% if pr.value_set.url %}
+{% if pr.terms.values() %}
+class {{pr.handle | toCamelCase}}Enum(str, Enum):
+{% elif pr.value_set.url %}
 class {{pr.handle | toCamelCase}}EnumURL(BaseModel):
     url: AnyUrl
 {% elif pr.value_set.path %}
 class {{pr.handle | toCamelCase}}EnumPath(BaseModel):
     path: PathType()
 {% else %}
-class {{pr.handle | toCamelCase}}Enum(str, Enum):
+    {% set _ = pv_enum_fail("Permissible value set unfound for " ~ pr.handle) %}
 {% endif %}
 {% for tm in pr.terms.values() %}
-    {{tm.value | to_snakecase}} = '{{tm.value}}'
+    {{tm.value | to_snakecase}} = {{ tm.value | pyrepr }}
 {% endfor %}
 {% endif %}
 {% endfor %}
   
-class {{node.handle | toCamelCase }}(BaseModel):
+class {{node.handle | toCamelCase }}(MDFBaseModel):
 {% for pr in node.props.values() %}
 {% if pr.value_domain == 'value_set' or pr.item_domain == 'value_set'%}
-{% if pr.value_set.url %}
+{% if pr.terms.values() %}
+    {{pr.handle}}: {{ [pr.handle | toCamelCase, 'Enum'] | join('') | maybe_list(pr) | maybe_optional(pr) }}
+{% elif pr.value_set.url %}
     {{pr.handle}}: {{ [pr.handle | toCamelCase, 'EnumURL'] | join('') | maybe_list(pr) | maybe_optional(pr) }}
 {% elif pr.value_set.path %}
     {{pr.handle}}: {{ [pr.handle | toCamelCase, 'EnumPath'] | join('') | maybe_list(pr) | maybe_optional(pr) }}
 {% else %}
-    {{pr.handle}}: {{ [pr.handle | toCamelCase, 'Enum'] | join('') | maybe_list(pr) | maybe_optional(pr) }}
+    {% set _ = pv_enum_fail("Permissible value set unfound for " ~ pr.handle) %}
 {% endif %}
 {% elif pr.value_domain == 'regexp' or pr.item_domain == 'regexp'%}
     {{pr.handle}}: {{ "MatchedStrType(r'{}')".format(pr.pattern) | maybe_list(pr) | maybe_optional(pr) }}
@@ -70,15 +77,17 @@ class {{node.handle | toCamelCase }}(BaseModel):
     {{pr.handle}}: {{typemap[pr.value_domain].__name__ | maybe_optional(pr)}}
 {% endif %}
 {% endif %}
+{% elif pr.value_domain == 'string'%}
+    {{pr.handle}}: {{ "str"| maybe_optional(pr) }}
 {% elif pr.value_domain == 'datetime' or pr.item_domain == 'datetime' %}
-    {{pr.handle}}: {{ "datetime" | maybe_list(pr) | maybe_optional(pr) }}
+    {{pr.handle}}: {{ "datetime" | maybe_list(pr) |maybe_optional(pr) }}
 {% else %}
 {% endif %}
 {% endfor %}
 
 {% endfor %}
 
-class {{"{}Data".format(model.handle)}}(BaseModel):
+class {{"{}Data".format(model.handle.replace("-","").replace("_","").capitalize())}}(BaseModel):
 {% for node in model.nodes.values() %}
     {{node.handle}}: {{node.handle | toCamelCase}}
 {% endfor %}

--- a/python/src/bento_mdf/mdf/validator.py
+++ b/python/src/bento_mdf/mdf/validator.py
@@ -8,7 +8,7 @@ from .reader import MDFReader
 from bento_meta.objects import Property
 from tempfile import NamedTemporaryFile
 from jinja2 import Environment, PackageLoader
-from typing import Any, List, NoReturn #, TYPE_CHECKING
+from typing import Any, List, NoReturn, Literal  # , TYPE_CHECKING
 from datetime import datetime
 from pydantic import BaseModel, TypeAdapter, ValidationError, AnyUrl
 from pydantic.json_schema import GenerateJsonSchema
@@ -20,9 +20,11 @@ jenv = Environment(
     trim_blocks=True,
 )
 
+
 # jinja helpers
-def toCamelCase(val : str) -> str:
+def toCamelCase(val: str) -> str:
     return "".join([x.capitalize() for x in val.split("_")])
+
 
 def normalize_operators(val: str) -> str:
     """Given a string, replace common operator characters with word equivalents.
@@ -52,6 +54,7 @@ def normalize_operators(val: str) -> str:
         .replace(">", " greater_than ")
     )
 
+
 def to_snakecase(
     val: str, prefix_if_digit: str = "digit", empty_fallback: str = "unspecified"
 ) -> str:
@@ -70,24 +73,29 @@ def to_snakecase(
         name = empty_fallback
     return name
 
-def to_unit_types(unitstr : str, typ : type(int) | type(float)) -> List[str]:
-    return [f"Annotated[{typ.__name__}, Unit('{u}')]" for u in unitstr.split(';')]
 
-def maybe_optional(val : str, prop : Property):
+def to_unit_types(unitstr: str, typ: type(int) | type(float)) -> List[str]:
+    return [f"Annotated[{typ.__name__}, Unit('{u}')]" for u in unitstr.split(";")]
+
+
+def maybe_optional(val: str, prop: Property):
     if prop.is_required:
         return val
     else:
         # the field is still required in pydantic unless we set a default None value
         return f"Optional[{val}] = None"
 
-def maybe_list(val : str, prop : Property):
+
+def maybe_list(val: str, prop: Property):
     if prop.value_domain == "list":
         return f"List[{val}]"
     else:
         return val
 
-def pv_enum_fail(msg : str) -> NoReturn:
+
+def pv_enum_fail(msg: str) -> NoReturn:
     raise ValueError(msg)
+
 
 # register jinja filters and globals
 jenv.filters["toCamelCase"] = toCamelCase
@@ -98,12 +106,14 @@ jenv.filters["maybe_list"] = maybe_list
 jenv.filters["pyrepr"] = repr
 jenv.globals["pv_enum_fail"] = pv_enum_fail
 
+AllowedValLevel = Literal["model", "node"]
+
 
 class GenerateQualJsonSchema(GenerateJsonSchema):
     # override to add $schema tag
-    def generate(self, schema, mode='validation'):
+    def generate(self, schema, mode="validation"):
         json_schema = super().generate(schema, mode=mode)
-        json_schema['$schema'] = self.schema_dialect
+        json_schema["$schema"] = self.schema_dialect
         return self.sort(json_schema)
 
 
@@ -117,7 +127,7 @@ class MDFDataValidator:
         "regexp": str,
         "url": AnyUrl,
         "TBD": Any,
-        }
+    }
 
     def __init__(self, mdf: MDFReader):
         self.model = mdf.model
@@ -126,7 +136,7 @@ class MDFDataValidator:
         self._node_classes = []
         self._enum_classes = []
         self._validation_errors = None
-        self._validation_warnings = None # warnings separate from errors
+        self._validation_warnings = None  # warnings separate from errors
         self.generate_data_model()
         self.import_data_model()
 
@@ -140,7 +150,10 @@ class MDFDataValidator:
 
     @property
     def model_class(self) -> str:
-        return self.module and self.module.__name__
+        model_class_name = toCamelCase(
+            self.model.handle.replace("-", "").replace("_", "")
+        )
+        return self.module and f"{model_class_name}Data"
 
     @property
     def node_classes(self) -> List:
@@ -166,13 +179,19 @@ class MDFDataValidator:
         for node in self.model.nodes.values():
             self._node_classes.append(toCamelCase(node.handle))
             for pr in node.props.values():
-                if pr.value_domain == 'value_set' or pr.item_domain == 'value_set':
+                if pr.value_domain == "value_set" or pr.item_domain == "value_set":
                     if pr.value_set.url:
-                        self._enum_classes.append("{}EnumURL".format(toCamelCase(pr.handle)))
+                        self._enum_classes.append(
+                            "{}EnumURL".format(toCamelCase(pr.handle))
+                        )
                     elif pr.value_set.path:
-                        self._enum_classes.append("{}EnumPath".format(toCamelCase(pr.handle)))
+                        self._enum_classes.append(
+                            "{}EnumPath".format(toCamelCase(pr.handle))
+                        )
                     else:
-                        self._enum_classes.append("{}Enum".format(toCamelCase(pr.handle)))
+                        self._enum_classes.append(
+                            "{}Enum".format(toCamelCase(pr.handle))
+                        )
         self._node_classes.sort()
         self._enum_classes.sort()
         template = jenv.get_template("pymodel.py.jinja2")
@@ -188,6 +207,7 @@ class MDFDataValidator:
         with NamedTemporaryFile(mode="w+", suffix=".py", delete=False) as modf:
             modname = "{}Data".format(self.model.handle)
             print(self.data_model, file=modf)
+            # print(self.data_model)
             modf.close()
             spec = importlib.util.spec_from_file_location(modname, modf.name)
             module = importlib.util.module_from_spec(spec)
@@ -197,22 +217,28 @@ class MDFDataValidator:
             Path(modf.name).unlink()
 
     @cache
-    def model_of(self, clsname : str):
-        if clsname != self.model_class and clsname not in self.node_classes and clsname not in self.enum_classes:
+    def model_of(self, clsname: str):
+        if (
+            clsname != self.model_class
+            and clsname not in self.node_classes
+            and clsname not in self.enum_classes
+        ):
             raise RuntimeError(f"Validation model does not contain class '{clsname}'")
         return eval("self.module.{}".format(clsname))
 
     @cache
-    def fields_of(self, clsname : str) -> List[str]:
+    def fields_of(self, clsname: str) -> List[str]:
         if clsname != self.model_class and clsname not in self.node_classes:
-            raise RuntimeError(f"Validation model does not contain node class '{clsname}'")
+            raise RuntimeError(
+                f"Validation model does not contain node class '{clsname}'"
+            )
         return [x for x in self.model_of(clsname).model_fields]
 
-    def props_of(self, clsname : str) -> List[str]:
+    def props_of(self, clsname: str) -> List[str]:
         return self.fields_of(clsname)
 
     @cache
-    def validator(self, clsname : str):
+    def validator(self, clsname: str):
         """
         Return a validator function appropriate to the class named 'clsname'
         """
@@ -222,7 +248,7 @@ class MDFDataValidator:
         else:
             return TypeAdapter(model).validate_python
 
-    def json_schema(self, clsname : str) -> dict | list:
+    def json_schema(self, clsname: str) -> dict | list:
         """
         Return a jsonable object representing a JSONSchema that can validate
         the given model class.
@@ -230,14 +256,20 @@ class MDFDataValidator:
 
         model = self.model_of(clsname)
         if issubclass(model, BaseModel):
-            return model.model_json_schema(
-                schema_generator=GenerateQualJsonSchema)
+            return model.model_json_schema(schema_generator=GenerateQualJsonSchema)
         else:
             return TypeAdapter(model).json_schema(
-                schema_generator=GenerateQualJsonSchema)
+                schema_generator=GenerateQualJsonSchema
+            )
 
-    def validate(self, node_name : str, data : dict | List[dict], strict : bool = False,
-                 verbose : bool = False) -> bool:
+    def validate(
+        self,
+        handle_name: str,
+        data: dict | List[dict],
+        validate_level: AllowedValLevel = "node",
+        strict: bool = False,
+        verbose: bool = False,
+    ) -> bool:
         """
         Validate a dict or list of dicts against a given model class.
         Returns true if all items are valid, false otherwise.
@@ -245,22 +277,28 @@ class MDFDataValidator:
         a dict whose keys are the index of the item in the submitted data list, and values
         which are lists of specific errors found in the item.
         ('last_validation_errors' is reset to None if validation succeeds.)
-        
+
         Arguments:
-            node_name: the name of the node to validate against
+            handle_name: the handle of the model/node to validate against
             data: a dict or list of dicts to validate
+            validate_level: the level of validation to perform. If 'model', validates at the model scope; if 'node', validates properties of the specified node. Default is 'node'.
             strict: if True, enforce strict validation on all fields/properties. Default is False.
             verbose: if True, print validation errors to stderr. Default is False.
         """
         dta = []
-        result = True
-        self._validation_errors = {}
-        self._validation_warnings = {}
-        clsname = toCamelCase(node_name)
         if isinstance(data, dict):
             dta = [data]
         else:
             dta = data
+        result = True
+        self._validation_errors = {}
+        self._validation_warnings = {}
+        # validate at model level
+        if handle_name == self.model.handle and validate_level == "model":
+            clsname = self.model_class
+        else:
+            # validate at node level
+            clsname = toCamelCase(handle_name)
         valf = self.validator(clsname)
         for i, rec in enumerate(dta):
             try:
@@ -273,8 +311,13 @@ class MDFDataValidator:
                 errs = []
                 for err in e.errors():
                     # handle enum violations if the enum is non-strict, treat as warning instead of error
-                    if err['type'] == "enum": 
-                        prop_name = err["loc"][0]
+                    if err["type"] == "enum":
+                        if validate_level == "model":
+                            node_name = err["loc"][0]
+                            prop_name = err["loc"][1]
+                        else:
+                            node_name = handle_name
+                            prop_name = err["loc"][0]
                         prop_instance = self.model.nodes[node_name].props[prop_name]
                         if not prop_instance.is_strict:
                             # non-strict enum violation, treat as warning
@@ -286,7 +329,7 @@ class MDFDataValidator:
                             errs.append(err)
                     else:
                         err = {"level": "error", **err}
-                        errs.append(err)            
+                        errs.append(err)
                 self._validation_errors[i] = errs
                 if len(warnings) > 0:
                     self._validation_warnings[i] = warnings

--- a/python/tests/samples/test-model-mdfdatavalidator.yml
+++ b/python/tests/samples/test-model-mdfdatavalidator.yml
@@ -1,0 +1,91 @@
+Handle: test_collision
+Version: "1.0.0"
+Nodes:
+  participant:
+    Props:
+      - guid
+      - participant_id
+      - race
+      - sex_at_birth
+      - occupation
+Relationships: {}
+PropDefinitions:
+  participant_id:
+    Desc: A sequence of letters, numbers, or characters that uniquely identifies the subject who has taken part in the investigation or research study.    
+    Term:
+      - Origin: caDSR
+        Code: '12220014'
+        Value: Subject Alternate Data Origin Identifier
+        Version: '1'
+    Type: string
+    Req: true
+    Private: false
+    Key: true
+  race: 
+    Desc: The text for reporting information about race based on the Office of Management and Budget (OMB) categories SPD 15 (spd15revision.gov).
+    Term:
+      - Origin: caDSR
+        Code: '2192199'
+        Value: Race Category Text
+        Version: "1.00"
+    Type:
+      value_type: list
+      item_type:
+        - "American Indian or Alaska Native"
+        - "Asian"
+        - "Black or African American"
+        - "Hispanic or Latino"
+        - "Middle Eastern or North African"
+        - "Native Hawaiian or other Pacific Islander"
+        - "Not Allowed to Collect"
+        - "Not Reported"
+        - "Unknown"
+        - "White"
+    Req: true
+    Strict: false
+    Private: false
+  sex_at_birth:
+    Desc: "A textual description of a person's sex at birth."
+    Term:
+      - Origin: caDSR
+        Code: '7572817'
+        Value: Person Sex at Birth Category
+        Version: "2.0"
+    Enum:
+      - "Female"
+      - "Intersex"
+      - "Male"
+      - "Not Reported"
+      - "Unknown"
+      - "Don't Know"
+      - "Decline to answer"
+      - "None of These Describe Me"
+      - "Prefer Not to Answer"
+    Req: true
+    Strict: false
+    Private: false
+  occupation:
+    Desc: "The text term that describes a person's occupation."
+    Term:
+      - Origin: caDSR
+        Code: '10156751'
+        Value: Person Occupation Category
+        Version: "1.0"
+    Enum:
+      - "Physician Assistant"
+      - "Nurse Practitioner"
+      - "Registered Nurse"
+    Req: false
+    Strict: false
+    Private: false
+  guid:
+    Desc: A unique sequence of characters used to identify, name, or characterize an attribute shared by all members of a class.
+    Term:
+      - Origin: caDSR
+        Code: '14534325'
+        Value: CCDI Property Unique Identifier
+        Version: "1.00"
+    Type: string
+    Req: false
+    Key: false
+    Private: false

--- a/python/tests/test_010mdf_datavalidator.py
+++ b/python/tests/test_010mdf_datavalidator.py
@@ -1,0 +1,476 @@
+"""Tests for bento_mdf.mdf.validator.MDFDataValidator."""
+
+from pathlib import Path
+import pytest
+from bento_mdf import MDFReader
+from bento_mdf.mdf.validator import MDFDataValidator
+from pydantic import ValidationError
+
+TDIR = Path("tests/").resolve() if Path("tests").exists() else Path().resolve()
+TEST_MODEL_VALIDATOR_FILE = TDIR / "samples" / "test-model-mdfdatavalidator.yml"
+
+
+@pytest.fixture
+def simple_validator():
+    """Create a validator from a test model."""
+    mdf = MDFReader(TEST_MODEL_VALIDATOR_FILE, handle="test_validator", )
+    return MDFDataValidator(mdf)
+
+
+class TestMDFDataValidatorInit:
+    """Tests for MDFDataValidator initialization."""
+
+    def test_init_creates_validator(self, simple_validator):
+        """Test that validator is properly initialized."""
+        assert isinstance(simple_validator, MDFDataValidator)
+        assert simple_validator.model is not None
+        assert simple_validator.data_model is not None
+        assert simple_validator.module is not None
+
+    def test_init_generates_node_classes(self, simple_validator):
+        """Test that node classes are generated during initialization."""
+        assert len(simple_validator.node_classes) > 0
+        # Check that node class names are in CamelCase
+        for cls in simple_validator.node_classes:
+            assert cls[0].isupper()
+
+    def test_init_generates_enum_classes(self, simple_validator):
+        """Test that enum classes are generated for value sets."""
+        # Test model should have some enum properties
+        assert isinstance(simple_validator.enum_classes, list)
+        assert len(simple_validator.enum_classes) > 0
+
+    def test_module_name_matches_handle(self, simple_validator):
+        """Test that generated module name matches model handle."""
+        assert simple_validator.model_class == "test_validatorData"
+
+
+class TestMDFDataValidatorProperties:
+    """Tests for MDFDataValidator property methods."""
+
+    def test_data_model_property_returns_string(self, simple_validator):
+        """Test that data_model property returns a string."""
+        assert isinstance(simple_validator.data_model, str)
+        assert len(simple_validator.data_model) > 0
+        # Should contain Python code
+        assert "class" in simple_validator.data_model
+
+    def test_module_property_returns_module(self, simple_validator):
+        """Test that module property returns a module object."""
+        assert simple_validator.module is not None
+        assert hasattr(simple_validator.module, "__name__")
+
+    def test_node_classes_property(self, simple_validator):
+        """Test that node_classes property returns sorted list."""
+        classes = simple_validator.node_classes
+        assert isinstance(classes, list)
+        assert classes == sorted(classes)
+
+    def test_enum_classes_property(self, simple_validator):
+        """Test that enum_classes property returns sorted list."""
+        classes = simple_validator.enum_classes
+        assert isinstance(classes, list)
+        assert classes == sorted(classes)
+
+    def test_last_validation_errors_initially_none(self, simple_validator):
+        """Test that last_validation_errors is None before validation."""
+        assert simple_validator.last_validation_errors is None
+
+    def test_last_validation_warnings_initially_none(self, simple_validator):
+        """Test that last_validation_warnings is None before validation."""
+        assert simple_validator.last_validation_warnings is None
+
+
+class TestMDFDataValidatorModelOf:
+    """Tests for model_of method."""
+
+    def test_model_of_valid_class(self, simple_validator):
+        """Test model_of with valid class name."""
+        # Get first node class
+        cls_name = simple_validator.node_classes[0]
+        model = simple_validator.model_of(cls_name)
+        assert model is not None
+
+    def test_model_of_invalid_class_raises_error(self, simple_validator):
+        """Test model_of with invalid class name raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="does not contain class"):
+            simple_validator.model_of("NonExistentClass")
+
+    def test_model_of_caches_results(self, simple_validator):
+        """Test that model_of caches its results."""
+        cls_name = simple_validator.node_classes[0]
+        model1 = simple_validator.model_of(cls_name)
+        model2 = simple_validator.model_of(cls_name)
+        assert model1 is model2
+
+
+class TestMDFDataValidatorFieldsOf:
+    """Tests for fields_of and props_of methods."""
+
+    def test_fields_of_returns_list(self, simple_validator):
+        """Test that fields_of returns a list of field names."""
+        cls_name = simple_validator.node_classes[0]
+        fields = simple_validator.fields_of(cls_name)
+        assert isinstance(fields, list)
+
+    def test_fields_of_invalid_class_raises_error(self, simple_validator):
+        """Test fields_of with invalid class name raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="does not contain node class"):
+            simple_validator.fields_of("NonExistentClass")
+
+    def test_props_of_returns_same_as_fields_of(self, simple_validator):
+        """Test that props_of returns same result as fields_of."""
+        cls_name = simple_validator.node_classes[0]
+        fields = simple_validator.fields_of(cls_name)
+        props = simple_validator.props_of(cls_name)
+        assert fields == props
+
+
+class TestMDFDataValidatorValidator:
+    """Tests for validator method."""
+
+    def test_validator_returns_callable(self, simple_validator):
+        """Test that validator returns a callable."""
+        cls_name = simple_validator.node_classes[0]
+        validator = simple_validator.validator(cls_name)
+        assert callable(validator)
+
+    def test_validator_caches_results(self, simple_validator):
+        """Test that validator caches its results."""
+        cls_name = simple_validator.node_classes[0]
+        validator1 = simple_validator.validator(cls_name)
+        validator2 = simple_validator.validator(cls_name)
+        assert validator1 is validator2
+
+
+class TestMDFDataValidatorJsonSchema:
+    """Tests for json_schema method."""
+
+    def test_json_schema_returns_dict(self, simple_validator):
+        """Test that json_schema returns a dictionary."""
+        cls_name = simple_validator.node_classes[0]
+        schema = simple_validator.json_schema(cls_name)
+        assert isinstance(schema, (dict, list))
+
+    def test_json_schema_contains_schema_tag(self, simple_validator):
+        """Test that generated JSON schema contains $schema tag."""
+        cls_name = simple_validator.node_classes[0]
+        schema = simple_validator.json_schema(cls_name)
+        if isinstance(schema, dict):
+            assert "$schema" in schema
+
+    def test_json_schema_valid_structure(self, simple_validator):
+        """Test that JSON schema has expected structure."""
+        cls_name = simple_validator.node_classes[0]
+        schema = simple_validator.json_schema(cls_name)
+        if isinstance(schema, dict):
+            # Should have typical JSON schema fields
+            assert "properties" in schema or "type" in schema
+
+
+class TestMDFDataValidatorValidate:
+    """Tests for validate method."""
+
+    def test_validate_with_valid_dict(self, simple_validator):
+        """Test validation with a valid single dict."""
+        # Create minimal valid data for participant node
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate("participant", data)
+        assert result is True
+
+    def test_validate_with_valid_list(self, simple_validator):
+        """Test validation with a list of dicts."""
+        data = [
+            {
+                "participant_id": "PART_001",
+                "race": ["White"],
+                "sex_at_birth": "Female"
+            },
+            {
+                "participant_id": "PART_002",
+                "race": ["Asian"],
+                "sex_at_birth": "Male"
+            }
+        ]
+        result = simple_validator.validate("participant", data)
+        assert result is True
+
+    def test_validate_sets_errors_on_failure(self, simple_validator):
+        """Test that validation errors are set when validation fails."""
+        # Invalid data - wrong type for participant_id
+        data = {
+            "participant_id": 12345,  # should be string
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate("participant", data, strict=True)
+        assert result is False
+        assert simple_validator.last_validation_errors is not None
+        assert isinstance(simple_validator.last_validation_errors, dict)
+
+    def test_validate_clears_errors_on_success(self, simple_validator):
+        """Test that validation errors are cleared on successful validation."""
+        # First fail validation
+        invalid_data = {
+            "participant_id": 12345,
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        simple_validator.validate("participant", invalid_data, strict=True)
+        
+        # Then succeed
+        valid_data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate("participant", valid_data)
+        assert result is True
+        assert simple_validator.last_validation_errors is None
+
+    def test_validate_with_strict_mode(self, simple_validator):
+        """Test validation extra field"""
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female",
+            "extra_field": "value"  # Extra field should fail
+        }
+        result = simple_validator.validate("participant", data)
+        # Strict mode should reject extra fields
+        assert result is False
+        assert len(simple_validator._validation_errors) == 1
+
+    def test_validate_error_contains_index(self, simple_validator):
+        """Test that validation errors contain record index."""
+        data = [
+            {
+                "participant_id": "PART_001",
+                "race": ["White"],
+                "sex_at_birth": "Female"
+            },
+            {
+                "participant_id": 12345,  # invalid - should be string
+                "race": ["White"],
+                "sex_at_birth": "Female"
+            }
+        ]
+        result = simple_validator.validate("participant", data, strict=True)
+        assert result is False
+        errors = simple_validator.last_validation_errors
+        # Check that error keys are indices
+        assert all(isinstance(k, int) for k in errors.keys())
+        # Second record (index 1) should have errors
+        assert 1 in errors
+
+    def test_validate_error_structure(self, simple_validator):
+        """Test the structure of validation errors."""
+        data = {
+            "participant_id": 12345,
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate("participant", data, strict=True)
+        assert result is False
+        errors = simple_validator.last_validation_errors
+        # Each error should have level and other fields
+        for idx, error_list in errors.items():
+            for err in error_list:
+                assert "level" in err
+                assert err["level"] in ["error", "warning"]
+
+    def test_validate_handles_list_of_valid_records(self, simple_validator):
+        """Test validation with multiple valid records."""
+        data = [
+            {
+                "participant_id": "PART_001",
+                "race": ["White"],
+                "sex_at_birth": "Female"
+            },
+            {
+                "participant_id": "PART_002",
+                "race": ["Asian"],
+                "sex_at_birth": "Male"
+            },
+            {
+                "participant_id": "PART_003",
+                "race": ["Black or African American"],
+                "sex_at_birth": "Unknown"
+            }
+        ]
+        result = simple_validator.validate("participant", data)
+        assert result is True
+
+    def test_validate_converts_dict_to_list(self, simple_validator):
+        """Test that single dict is converted to list internally."""
+        dict_data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        list_data = [{
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }]
+        
+        result1 = simple_validator.validate("participant", dict_data)
+        result2 = simple_validator.validate("participant", list_data)
+        
+        # Should have same result
+        assert result1 == result2
+        assert result1 is True
+
+
+class TestMDFDataValidatorEnumValidation:
+    """Tests for enum validation with strict and non-strict enums."""
+
+    def test_validate_non_strict_enum_with_valid_value(self, simple_validator):
+        """Test that valid enum values pass validation."""
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"  # Valid enum value
+        }
+        result = simple_validator.validate("participant", data)
+        assert result is True
+        assert simple_validator.last_validation_warnings is None
+
+    def test_validate_non_strict_enum_violation_creates_warning(self, simple_validator):
+        """Test that non-strict enum violations are treated as warnings."""
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Non-Binary"  # Invalid value but non-strict enum
+        }
+        result = simple_validator.validate("participant", data)
+        # Non-strict enum violations should still fail validation
+        assert result is False
+        # But should create warnings instead of errors
+        if simple_validator.last_validation_warnings:
+            warnings = simple_validator.last_validation_warnings
+            assert 0 in warnings
+            # Check that warning has proper structure
+            for warning in warnings[0]:
+                assert warning["level"] == "warning"
+                assert warning["type"] == "enum"
+
+    def test_validate_non_strict_list_enum_violation(self, simple_validator):
+        """Test non-strict enum violations in list type properties."""
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White", "Other Race"],  # "Other Race" not in enum but non-strict
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate("participant", data)
+        # Should fail but create warning
+        assert result is False
+        # Check warnings were created
+        if simple_validator.last_validation_warnings:
+            assert 0 in simple_validator.last_validation_warnings
+
+    def test_validate_optional_non_strict_enum(self, simple_validator):
+        """Test optional non-strict enum property."""
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female",
+            "occupation": "Software Engineer"  # Invalid value but optional and non-strict
+        }
+        result = simple_validator.validate("participant", data)
+        assert result is False
+        # Should generate warnings for invalid enum value
+        if simple_validator.last_validation_warnings:
+            warnings = simple_validator.last_validation_warnings[0]
+            assert any(w["type"] == "enum" for w in warnings)
+
+    def test_validation_warnings_property(self, simple_validator):
+        """Test that validation warnings are properly set."""
+        # Initially None
+        assert simple_validator.last_validation_warnings is None
+        
+        # After failed validation with non-strict enum
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Non-Binary"
+        }
+        simple_validator.validate("participant", data)
+        # Warnings should be set if non-strict enum violated
+        if simple_validator.last_validation_warnings:
+            assert isinstance(simple_validator.last_validation_warnings, dict)
+
+
+class TestMDFDataValidatorHelperFunctions:
+    """Tests for helper functions used in validator."""
+
+    def test_to_camel_case(self):
+        """Test toCamelCase helper function."""
+        from bento_mdf.mdf.validator import toCamelCase
+        assert toCamelCase("test_node") == "TestNode"
+        assert toCamelCase("case") == "Case"
+        assert toCamelCase("my_sample_type") == "MySampleType"
+
+    def test_to_snakecase(self):
+        """Test to_snakecase helper function."""
+        from bento_mdf.mdf.validator import to_snakecase
+        assert to_snakecase("TestNode") == "testnode"
+        assert to_snakecase("My Sample Type") == "my_sample_type"
+        assert to_snakecase("Test-Node") == "test_minus_node"
+        assert to_snakecase("123test") == "digit_123test"
+        assert to_snakecase("") == "unspecified"
+
+    def test_normalize_operators(self):
+        """Test normalize_operators helper function."""
+        from bento_mdf.mdf.validator import normalize_operators
+        assert "plus" in normalize_operators("test+value")
+        assert "minus" in normalize_operators("test-value")
+        assert "percent" in normalize_operators("test%value")
+
+
+class TestMDFDataValidatorIntegration:
+    """Integration tests for MDFDataValidator."""
+
+    def test_full_validation_workflow(self, simple_validator):
+        """Test complete validation workflow from model load to validation."""
+        # This is an end-to-end test
+        assert simple_validator.model is not None
+        assert len(simple_validator.node_classes) > 0
+        
+        # Pick a node and validate some data
+        node_name = "participant"
+        data = {
+            "participant_id": "PART_001",
+            "race": ["White"],
+            "sex_at_birth": "Female"
+        }
+        result = simple_validator.validate(node_name, data)
+        assert result is True
+
+    def test_validator_with_participant_node(self, simple_validator):
+        """Test validator with participant node."""
+        # Test the participant node
+        data = {
+            "participant_id": "PART_001",
+            "race": ["Asian", "White"],  # Multiple values allowed in list
+            "sex_at_birth": "Male",
+            "occupation": "Physician Assistant",
+            "guid": "550e8400-e29b-41d4-a716-446655440000"
+        }
+        result = simple_validator.validate("participant", data)
+        assert result is True
+
+    def test_generated_code_quality(self, simple_validator):
+        """Test that generated Python code is valid."""
+        code = simple_validator.data_model
+        # Should be valid Python
+        assert "import" in code
+        assert "class" in code
+        assert "BaseModel" in code
+        
+        # Should not have syntax errors (implicitly tested by successful import)
+        assert simple_validator.module is not None

--- a/python/tests/test_010mdf_datavalidator.py
+++ b/python/tests/test_010mdf_datavalidator.py
@@ -42,7 +42,7 @@ class TestMDFDataValidatorInit:
 
     def test_module_name_matches_handle(self, simple_validator):
         """Test that generated module name matches model handle."""
-        assert simple_validator.model_class == "test_validatorData"
+        assert simple_validator.model_class == "TestvalidatorData"
 
 
 class TestMDFDataValidatorProperties:


### PR DESCRIPTION
Added Fixes

- Added helper functions to handle special string cases occurred in CCDI model and DCC model
- Fixed the model rendering issue while generating model file using jinja2 template
- Included str type properties (required and non-required) in the rendered model file
- Made the validator reject any fields that are not explicitly defined on the model
- Redefined PV violation for non-strict properties as warning instead of regular error
- Added unittest for MDFDataValidator class

(ticket DATATEAM-445)