### PR TITLE
Feature - helpful validation errors from validator.py and test_mdf

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bento-mdf"
-version = "0.12.1"
+version = "0.13.0"
 description = "Python driver/validator for Bento Model Description Format"
 authors = [
   { name = "Mark A. Jensen", email = "mark.jensen@nih.gov" },

--- a/python/src/bento_mdf/bin/val_mdf.py
+++ b/python/src/bento_mdf/bin/val_mdf.py
@@ -28,6 +28,13 @@ ap.add_argument(
     help="MDF yaml files for validation",
 )
 ap.add_argument("--log-file", help="Log file name")
+ap.add_argument(
+    "-v",
+    "--verbose",
+    help="Emit detailed schema validation error information",
+    action="store_true",
+    dest="verbose",
+)
 
 
 def test(args, logger):
@@ -37,7 +44,7 @@ def test(args, logger):
         retval += 1
     if not v.load_and_validate_yaml():
         retval += 1
-    if not v.validate_instance_with_schema():
+    if not v.validate_instance_with_schema(verbose=args.verbose):
         retval += 1
     if not retval:
         for f in args.mdf_files:

--- a/python/src/bento_mdf/validator.py
+++ b/python/src/bento_mdf/validator.py
@@ -258,7 +258,10 @@ class MDFValidator:
                 continue
         return None
 
-    def validate_instance_with_schema(self) -> MergedOptions | None:
+    def validate_instance_with_schema(
+        self,
+        verbose: bool = False,
+    ) -> MergedOptions | None:
         """Validate the instance with the schema."""
         if not self.schema:
             self.logger.warning("No valid schema; skipping this validation")
@@ -282,6 +285,9 @@ class MDFValidator:
                     )
                 else:
                     self.logger.error(e.message)
+                if verbose:
+                    for line in str(e).splitlines():
+                        self.logger.error("[detail] %s", line)
             if self.raise_error:
                 raise
             return None

--- a/python/src/bento_mdf/validator.py
+++ b/python/src/bento_mdf/validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc
 import logging
 from io import BufferedRandom, TextIOWrapper
 from pathlib import Path
@@ -14,6 +15,7 @@ from delfick_project.option_merge.merge import MergedOptions
 from jsonschema import Draft6Validator, SchemaError, ValidationError, validate
 from referencing.exceptions import Unresolvable
 from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode, SequenceNode
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
@@ -204,6 +206,58 @@ class MDFValidator:
             return None
         return self.instance
 
+    def _find_node_at_path(
+        self,
+        root: MappingNode | SequenceNode,
+        path: collections.abc.Sequence,
+    ) -> MappingNode | SequenceNode | None:
+        """Walk a YAML node tree following the given path."""
+        node = root
+        for key in path:
+            if isinstance(node, MappingNode):
+                for key_node, value_node in node.value:
+                    if key_node.value == str(key):
+                        node = value_node
+                        break
+                else:
+                    return None
+            elif isinstance(node, SequenceNode):
+                if isinstance(key, int) and key < len(node.value):
+                    node = node.value[key]
+                else:
+                    return None
+            else:
+                return None
+        return node
+
+    def _find_yaml_location(
+        self,
+        path: collections.abc.Sequence,
+    ) -> tuple[str, int, int] | None:
+        """Find the YAML source file, line number, and column for a given instance path."""
+        for inst_file in self.inst_files:
+            try:
+                if isinstance(inst_file, (str, Path)):
+                    with Path(inst_file).open(encoding="UTF-8") as f:
+                        root = yaml.compose(f, Loader=yaml.SafeLoader)
+                elif hasattr(inst_file, "seek"):
+                    inst_file.seek(0)
+                    root = yaml.compose(inst_file, Loader=yaml.SafeLoader)
+                else:
+                    continue
+                if root is None:
+                    continue
+                node = self._find_node_at_path(root, path)
+                if node is not None:
+                    return (
+                        node.start_mark.name,
+                        node.start_mark.line + 1,
+                        node.start_mark.column + 1,
+                    )
+            except Exception:  # noqa: BLE001
+                continue
+        return None
+
     def validate_instance_with_schema(self) -> MergedOptions | None:
         """Validate the instance with the schema."""
         if not self.schema:
@@ -217,7 +271,17 @@ class MDFValidator:
             validate(instance=self.instance.as_dict(), schema=self.schema)
         except ValidationError:
             for e in Draft6Validator(self.schema).iter_errors(self.instance.as_dict()):
-                self.logger.exception(e)
+                loc = self._find_yaml_location(e.absolute_path)
+                if loc:
+                    self.logger.error(
+                        "%s (in %s, line %d, col %d)",
+                        e.message,
+                        loc[0],
+                        loc[1],
+                        loc[2],
+                    )
+                else:
+                    self.logger.error(e.message)
             if self.raise_error:
                 raise
             return None

--- a/python/tests/test_001validate.py
+++ b/python/tests/test_001validate.py
@@ -96,6 +96,19 @@ def test_instance_not_valid_wrt_schema():
         v.validate_instance_with_schema()
 
 
+def test_validation_errors_include_line_numbers(caplog):
+    v = MDFValidator(
+        test_schema_file,
+        *test_mdf_files_invalid_wrt_schema,
+    )
+    assert v.load_and_validate_schema()
+    assert v.load_and_validate_yaml()
+    with caplog.at_level("ERROR"):
+        result = v.validate_instance_with_schema()
+    assert result is None
+    assert any("line" in rec.message for rec in caplog.records)
+
+
 def test_list_type():
     v = MDFValidator(test_latest_schema, *test_list_type_files)
     assert v

--- a/python/tests/test_005mdf_val.py
+++ b/python/tests/test_005mdf_val.py
@@ -14,6 +14,7 @@ TEST_ERR_MODEL_FILE = TDIR / "samples" / "test-missing-prop-defn.yml"
 def test_missing_defn() -> None:
     args = Namespace()
     args.schema = None
+    args.verbose = False
     args.mdf_files = [open(TEST_MODEL_BB_FILE)]
     logger = logging.getLogger("test-mdf")
     assert test(args, logger) == 0

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 
 [[package]]
 name = "bento-mdf"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 
 [[package]]
 name = "bento-mdf"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Errors in YAML validation against the JSON schema come from the jsonschema validate() method. Up until now, the error object that is returned as just been dumped to the log. Sometimes these dumps are 100s of lines and completely obscure the actual error that needs fixing in the model files.

I used Claude Code to update the error logging so that
* only the error message itself appears in the log, unless the 'verbose' option is set
* the line number and column number in the offending YAML file is brought through to the error message.

(ticket DATATEAM-447) 
