### PR TITLE
Fixed a bug that causes failure of MDFDataValidator instance

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test-build:
-    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.25
+    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.1.2
     with:
       workdir: ./python
       versions: |

--- a/python/src/bento_mdf/mdf/validator.py
+++ b/python/src/bento_mdf/mdf/validator.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError, AnyUrl
 from pydantic.json_schema import GenerateJsonSchema
 from pdb import set_trace
 import keyword
+import hashlib
 
 jenv = Environment(
     loader=PackageLoader("bento_mdf", package_path="mdf/templates"),
@@ -71,7 +72,9 @@ def to_snakecase(
     # Handle empty str
     if name == "":
         name = empty_fallback
-    return name
+    # add short hash to avoid two terms that might turn into the same name after lower() and operator normalization
+    h = hashlib.md5(val.encode()).hexdigest()[:6]
+    return f"{name}_{h}"
 
 
 def to_unit_types(unitstr: str, typ: type(int) | type(float)) -> List[str]:

--- a/python/tests/test_010mdf_datavalidator.py
+++ b/python/tests/test_010mdf_datavalidator.py
@@ -1,6 +1,7 @@
 """Tests for bento_mdf.mdf.validator.MDFDataValidator."""
 
 from pathlib import Path
+import re
 import pytest
 from bento_mdf import MDFReader
 from bento_mdf.mdf.validator import MDFDataValidator
@@ -418,11 +419,16 @@ class TestMDFDataValidatorHelperFunctions:
     def test_to_snakecase(self):
         """Test to_snakecase helper function."""
         from bento_mdf.mdf.validator import to_snakecase
-        assert to_snakecase("TestNode") == "testnode"
-        assert to_snakecase("My Sample Type") == "my_sample_type"
-        assert to_snakecase("Test-Node") == "test_minus_node"
-        assert to_snakecase("123test") == "digit_123test"
-        assert to_snakecase("") == "unspecified"
+
+        assert re.fullmatch(r"testnode_[0-9a-f]{6}", to_snakecase("TestNode"))
+        assert re.fullmatch(
+            r"my_sample_type_[0-9a-f]{6}", to_snakecase("My Sample Type")
+        )
+        assert re.fullmatch(
+            r"test_minus_node_[0-9a-f]{6}", to_snakecase("Test-Node")
+        )
+        assert re.fullmatch(r"digit_123test_[0-9a-f]{6}", to_snakecase("123test"))
+        assert re.fullmatch(r"unspecified_[0-9a-f]{6}", to_snakecase(""))
 
     def test_normalize_operators(self):
         """Test normalize_operators helper function."""


### PR DESCRIPTION
(ref: DATATEAM-546)
Added Patch

- This is to fix the failure of MDFDataValidator initiation when two terms within an Enum property differing only by letter case.
- Solution: Added 6 digits of hash at the end. This also prevents future conflicts when creating terms during MDFDataValidator initiation.
- Modifed unittest accordingly.