### PR TITLE
feat(DATATEAM-533): support per-End Req attribute on relationships

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.26
     with:
       workdir: ./python

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.1.1
+    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.1.2
     with:
       workdir: ./python
       versions: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 jobs:
   test-build:
+    permissions:
+      content: read
+      packages: read
     uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.26
     with:
       workdir: ./python

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test-build:
-    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.25
+    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.26
     with:
       workdir: ./python
       versions: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test-build:
     permissions:
-      content: read
+      contents: read
       packages: read
     uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.26
     with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.0.26
+    uses: CBIIT/bento-workflows/.github/workflows/test-build.yml@v3.1.1
     with:
       workdir: ./python
       versions: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,6 @@
 name: ci-cd
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-build:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bento-mdf"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python driver/validator for Bento Model Description Format"
 authors = [
   { name = "Mark A. Jensen", email = "mark.jensen@nih.gov" },

--- a/python/src/bento_mdf/mdf/convert.py
+++ b/python/src/bento_mdf/mdf/convert.py
@@ -295,8 +295,8 @@ def entity_to_spec(ent: Entity, spec: dict = None) -> dict:
                     break
     elif isinstance(ent, Edge):
         # note that edge mdf specs must be merged correctly in the caller
-        if ent.is_required:
-            spec["Req"] = True
+        if ent.is_required is not None:
+            spec["Req"] = ent.is_required
         if ent.multiplicity:
             spec["Mul"] = ent.multiplicity
         spec["Src"] = ent.src.handle

--- a/python/src/bento_mdf/mdf/reader.py
+++ b/python/src/bento_mdf/mdf/reader.py
@@ -280,6 +280,8 @@ class MDFReader:
                 # to the Edge, _rather than_ tags set in the "edge key" or spec
                 # level
                 spec["Tags"] = ends.get("Tags") or spec.get("Tags")
+                # if Req is set in the Ends entry, it overrides the spec level
+                spec["Req"] = ends.get("Req") if ends.get("Req") is not None else spec.get("Req")
                 edge = self.model.add_edge(
                     spec_to_entity(
                         e,

--- a/python/src/bento_mdf/mdf/writer.py
+++ b/python/src/bento_mdf/mdf/writer.py
@@ -79,6 +79,10 @@ class MDFWriter:
                 top["Desc"] = dfDesc
             if not top["Desc"]:
                 del top["Desc"]
+            # raise common Req (if all Ends share the same value, hoist it)
+            req_values = [x.get("Req") for x in edge_specs[hdl]]
+            if all(v is not None for v in req_values) and len(set(req_values)) == 1:
+                top["Req"] = req_values[0]
             # merge props - this logic raises all Props specified in
             # Ends members to the Relationship[<handle>] level
             # (MDF schema does not currently allow Props to be specified
@@ -98,6 +102,8 @@ class MDFWriter:
                         del spec["Desc"]
                 if spec.get("Props"):
                     del spec["Props"]
+                if "Req" in spec and spec.get("Req") == top.get("Req"):
+                    del spec["Req"]
                 top["Ends"].append(spec)
             self._mdf["Relationships"][hdl] = top
 

--- a/python/tests/samples/test-model-req-ends.yml
+++ b/python/tests/samples/test-model-req-ends.yml
@@ -1,0 +1,44 @@
+Handle: test_req_ends
+Nodes:
+  case:
+    Props:
+      - case_id
+  sample:
+    Props:
+      - sample_type
+  diagnosis:
+    Props:
+      - disease
+  file:
+    Props:
+      - file_name
+Relationships:
+  of_case:
+    Props: ~
+    Mul: many_to_one
+    Ends:
+      - Src: sample
+        Dst: case
+        Req: true
+      - Src: diagnosis
+        Dst: case
+        Req: false
+  of_sample:
+    Props: ~
+    Mul: many_to_one
+    Ends:
+      - Src: file
+        Dst: sample
+        Req: true
+      - Src: diagnosis
+        Dst: sample
+        Req: true
+PropDefinitions:
+  case_id:
+    Type: string
+  sample_type:
+    Type: string
+  disease:
+    Type: string
+  file_name:
+    Type: string

--- a/python/tests/samples/test-model-req-ends.yml
+++ b/python/tests/samples/test-model-req-ends.yml
@@ -26,13 +26,12 @@ Relationships:
   of_sample:
     Props: ~
     Mul: many_to_one
+    Req: true
     Ends:
       - Src: file
         Dst: sample
-        Req: true
       - Src: diagnosis
         Dst: sample
-        Req: true
 PropDefinitions:
   case_id:
     Type: string

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -535,8 +535,8 @@ def test_edge_req_from_ends_mixed() -> None:
     assert diag_case.is_required is False
 
 
-def test_edge_req_from_ends_uniform() -> None:
-    """Test that uniform per-End Req values are applied to all edges."""
+def test_edge_req_from_ends_toplevel() -> None:
+    """Test that uniform Edge-level Req values are applied to all edges."""
     m = MDF(TDIR / "samples" / "test-model-req-ends.yml", handle="test_req_ends")
     # of_sample: both Ends have Req: true
     file_sample = m.model.edges[("of_sample", "file", "sample")]

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -523,3 +523,31 @@ def test_use_null_cde_helper_function() -> None:
     assert property_uses_null_cde(imaging_software) is True
     assert property_uses_null_cde(processing_method) is False
     assert property_uses_null_cde(sample_id) is False
+
+
+def test_edge_req_from_ends_mixed() -> None:
+    """Test that per-End Req values are applied to individual edges."""
+    m = MDF(TDIR / "samples" / "test-model-req-ends.yml", handle="test_req_ends")
+    # of_case: sample->case has Req: true, diagnosis->case has Req: false
+    sample_case = m.model.edges[("of_case", "sample", "case")]
+    diag_case = m.model.edges[("of_case", "diagnosis", "case")]
+    assert sample_case.is_required is True
+    assert diag_case.is_required is False
+
+
+def test_edge_req_from_ends_uniform() -> None:
+    """Test that uniform per-End Req values are applied to all edges."""
+    m = MDF(TDIR / "samples" / "test-model-req-ends.yml", handle="test_req_ends")
+    # of_sample: both Ends have Req: true
+    file_sample = m.model.edges[("of_sample", "file", "sample")]
+    diag_sample = m.model.edges[("of_sample", "diagnosis", "sample")]
+    assert file_sample.is_required is True
+    assert diag_sample.is_required is True
+
+
+def test_edge_req_inherited_from_relationship_level() -> None:
+    """Test that relationship-level Req is inherited when Ends don't specify it."""
+    m = MDF(TDIR / "samples" / "test-model.yml", handle="test")
+    # test-model.yml has no Req on Ends or relationship level for of_case
+    sample_case = m.model.edges[("of_case", "sample", "case")]
+    assert sample_case.is_required is None or sample_case.is_required is False

--- a/python/tests/test_003write_mdf.py
+++ b/python/tests/test_003write_mdf.py
@@ -284,3 +284,35 @@ def test_write_use_null_cde_only_on_cadsr_terms():
 
     assert "useNullCDE" in cadsr_terms[0]
     assert "useNullCDE" not in ncit_terms[0]
+
+
+def test_write_req_on_ends_mixed():
+    """Test that mixed Req values stay on individual Ends, not hoisted to relationship."""
+    m = MDFReader(TDIR / "samples" / "test-model-req-ends.yml", handle="test_req_ends")
+    wr_m = MDFWriter(model=m.model)
+    mdf = wr_m.write_mdf()
+
+    # of_case has mixed Req (true on sample->case, false on diagnosis->case)
+    of_case = mdf["Relationships"]["of_case"]
+    # Req should NOT be at the relationship level since values differ
+    assert "Req" not in of_case
+
+    ends = {(e["Src"], e["Dst"]): e for e in of_case["Ends"]}
+    assert ends[("sample", "case")].get("Req") is True
+    assert ends[("diagnosis", "case")].get("Req") is False
+
+
+def test_write_req_on_ends_uniform():
+    """Test that uniform Req values are hoisted to relationship level."""
+    m = MDFReader(TDIR / "samples" / "test-model-req-ends.yml", handle="test_req_ends")
+    wr_m = MDFWriter(model=m.model)
+    mdf = wr_m.write_mdf()
+
+    # of_sample has uniform Req: true on both Ends
+    of_sample = mdf["Relationships"]["of_sample"]
+    # Req should be hoisted to relationship level
+    assert of_sample.get("Req") is True
+
+    # Individual Ends should NOT have Req (stripped as redundant)
+    for end in of_sample["Ends"]:
+        assert "Req" not in end

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -296,6 +296,18 @@ defs:
           Human-readable description of the relationship.
         type: string
       Mul:
+        description: |
+          The multiplicity of the relationship:
+            one_to_one - any source node instance may have this relationship with one
+              and only one destination node instance
+            many_to_many - any source node instance may have this relationship with one
+              or more destination node instances, and vice versa
+            one_to_many - any source node instance my have this relationship with one
+              or more destination node instances, but any destination node instance may
+              have this relationship with one and only one source node instance
+            many_to_one - any destination node instance my have this relationship with one
+              or more source node instances, but any source node instance may
+              have this relationship with one and only one destination node instance
         # here, the "default" multiplicity for all Src->Dst pairs
         type: string
         enum:
@@ -303,6 +315,11 @@ defs:
           - one_to_many
           - many_to_one
           - many_to_many
+      Req:
+        description: |
+          Boolean indicating whether the relationship is required. If a relationship is
+          required, it means that if the database contains an instance of either end node,
+          it must also possess a relationship with an instance of the other end node.
       Props:
         oneOf:
           -

--- a/schema/mdf-schema.yaml
+++ b/schema/mdf-schema.yaml
@@ -324,6 +324,8 @@ defs:
             Dst:
               $ref: "#/defs/snake_case_id"
               # and need to be nodes defined in Nodes:
+            Req:
+              type: boolean
             Mul:
               # here, Src->Dst specific multiplicity
               # overrides default above


### PR DESCRIPTION
Enable the Req (is_required) attribute to be specified at the individual Ends level of a Relationship, not just at the Relationship level. This allows different Src->Dst pairs within the same relationship to have different requirement semantics.

Changes:
- schema: add Req: boolean to Ends object properties in mdf-schema.yaml
- reader: extract Req from Ends entries, overriding relationship-level Req when present (using is-not-None check to preserve explicit false)
- convert: emit Req on Edge spec when is_required is not None (was only emitting when truthy, which dropped explicit false values)
- writer: consolidate Req like Mul/Desc — hoist to relationship level when uniform across all Ends, keep on individual Ends when mixed

Tests:
- Reader tests for mixed, uniform, and inherited Req values
- Writer tests for correct Req placement in output YAML
- New sample model test-model-req-ends.yml exercising both scenarios