### PR TITLE
DATATEAM-692: preserve EDP enum references during MDF parsing

### DIFF
--- a/python/src/bento_mdf/mdf/reader.py
+++ b/python/src/bento_mdf/mdf/reader.py
@@ -466,9 +466,16 @@ class MDFReader:
                 prop.value_set.url is not None or
                 len(prop.value_set.edp_terms) > 0
             ):  # enum as reference
+                is_edp_reference = len(prop.value_set.edp_terms) > 0
+
                 if self.ignore_enum_by_reference:
                     self.logger.info(
                         "Ignoring enums by reference in property '%s'",
+                        prop.handle,
+                    )
+                elif is_edp_reference:
+                    self.logger.info(
+                        "Preserving EDP enum reference in property '%s' without resolving terms",
                         prop.handle,
                     )
                 else:

--- a/python/tests/test_002mdf.py
+++ b/python/tests/test_002mdf.py
@@ -1,10 +1,8 @@
 """Tests for bento_mdf.mdf."""
 
-import json
 from pathlib import Path
 
 import pytest
-import responses
 from bento_mdf.mdf import MDF, convert_github_url
 from bento_meta.entity import ArgError
 from bento_meta.model import Model
@@ -307,39 +305,19 @@ class TestEDPFeatures:
 
     def test_object_creation_for_edp(self) -> None:
         """
-        Test that property, value_set, terms created correctly for CDE/EDP
-        (both enum - term specification, reading an EDP definition)
+        Test that model properties preserve EDP enum references without resolving
+        EDP terms during MDF parsing.
         """
-        if self._sts_is_up():
-            m = MDF(TDIR / "samples" / "test-model-edp-enum.yml", handle="test", raise_error=True)
-        else:
-            with open(TDIR / "samples" / "edp-terms-response.json") as f:
-                sex_at_birth_terms = json.load(f)
-            with open(TDIR / "samples" / "edp-race-terms-response.json") as f:
-                race_terms = json.load(f)
-            with responses.RequestsMock() as rsps:
-                rsps.add_passthru("https://")
-                rsps.add(
-                    responses.GET,
-                    "http://localhost:8000/v2/edp/caDSR/7572817/2.0/terms",
-                    json=sex_at_birth_terms,
-                    status=200,
-                )
-                rsps.add(
-                    responses.GET,
-                    "http://localhost:8000/v2/edp/caDSR/2192199/1.00/terms",
-                    json=race_terms,
-                    status=200,
-                )
+        m = MDF(
+            TDIR / "samples" / "test-model-edp-enum.yml",
+            handle="test",
+            raise_error=True,
+        )
 
-                m = MDF(TDIR / "samples" / "test-model-edp-enum.yml", handle="test",
-                        raise_error=True)
-
-        pr = m.model.nodes['participant'].props['sex_at_birth']
+        pr = m.model.nodes["participant"].props["sex_at_birth"]
         assert pr.value_domain == "value_set"
         assert list(pr.value_set.edp_terms.values())[0].origin_id == "7572817"
-        term_values = set(x.value for x in pr.terms.values())
-        assert {"Female", "Male", "Intersex", "None of these describe me"} <= term_values
+        assert pr.terms == {}
 
     def test_parse_edp_mdf(self) -> None:
         """Test parsing of EDP props and terms yaml."""


### PR DESCRIPTION
This PR adjusts enum-by-reference handling for EDP references during MDF parsing.

**Context**: in bento-mdb, model changelog generation now relies on normal enum-by-reference resolution so model properties with referenced value sets get usable PVs in MDB/STS. However, EDP enum references are a special case. For a model property like:
```
Enum:
  - Origin: CRDC
    Code: CRDC0002
    Version: "1"
```
bento-mdb does not need bento-mdf to fetch every EDP term from STS during parsing. It only needs the EDP reference to be preserved, so the changelog can link the model property directly to the existing EDP value set already loaded into MDB.

Previously, with enum-by-reference resolution enabled, bento-mdf attempted to resolve EDP references by calling STS. That created a problem for GitHub-hosted Actions, because internal STS endpoints may be VPN-only and unreachable from public runners.

**This PR makes the behavior more case-specific:**

- normal path/url enum references still resolve as before;
- EDP enum references are preserved but not resolved through STS during normal MDF parsing;
- the EDP reference remains available on value_set.edp_terms;
- downstream bento-mdb can still generate the correct property-to-EDP-value-set link.

Tests were updated to assert that EDP enum references are preserved without loading EDP terms during MDF parsing.

**Validation**:
```
PYTHONPATH=src uv run --extra dev pytest tests/test_002mdf.py -q
50 passed, 1 warning
```
```
PYTHONPATH=src uv run --extra dev pytest -q
288 passed, 1 skipped, 6 warnings
```